### PR TITLE
feat!: replace BEM class names with CSS custom properties and classNames API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,43 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  deploy:
+    needs: release
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'vitaliiburlaka/react-noti' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        env:
+          HUSKY: 0
+
+      - name: Build demo
+        run: npm run examples:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: examples/build
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,23 @@
 # [2.0.0](https://github.com/vitaliiburlaka/react-noti/compare/v1.0.0...v2.0.0) (2026-06-15)
 
-
-* feat(deps)!: bump to react 19.2 and replace styled-components peer with emotion ([c00cab4](https://github.com/vitaliiburlaka/react-noti/commit/c00cab46aaba2a582fe741804a613ed251ef2ff1))
-
+- feat(deps)!: bump to react 19.2 and replace styled-components peer with emotion ([c00cab4](https://github.com/vitaliiburlaka/react-noti/commit/c00cab46aaba2a582fe741804a613ed251ef2ff1))
 
 ### Bug Fixes
 
-* **toast:** restore progress-bar animation after emotion keyframes migration ([a7908da](https://github.com/vitaliiburlaka/react-noti/commit/a7908da00ca7d9be656af0e4f0f7453a00da1045))
-
+- **toast:** restore progress-bar animation after emotion keyframes migration ([a7908da](https://github.com/vitaliiburlaka/react-noti/commit/a7908da00ca7d9be656af0e4f0f7453a00da1045))
 
 ### Features
 
-* **ci:** add CI workflow and release configuration with semantic-release ([d471339](https://github.com/vitaliiburlaka/react-noti/commit/d471339bbd19fc251a9d974ffab610c217d33142))
-* **types:** export public types; strict typescript on examples; drop PropTypes ([5784580](https://github.com/vitaliiburlaka/react-noti/commit/5784580cfaa7e7a3e43506d5659743ef2a188bc8))
-
+- **ci:** add CI workflow and release configuration with semantic-release ([d471339](https://github.com/vitaliiburlaka/react-noti/commit/d471339bbd19fc251a9d974ffab610c217d33142))
+- **types:** export public types; strict typescript on examples; drop PropTypes ([5784580](https://github.com/vitaliiburlaka/react-noti/commit/5784580cfaa7e7a3e43506d5659743ef2a188bc8))
 
 ### BREAKING CHANGES
 
-* The styled-components peer dependency has been
-replaced with @emotion/react and @emotion/styled (both ^11). Consumers
-upgrading react-noti must uninstall styled-components (if it was only
-installed for this library) and install the two @emotion packages.
-The public component API (`<ReactNoti />`, `notify`, `POSITION`) is
-unchanged. UMD bundle externals also rename: `styled-components` ->
-`styled` becomes `@emotion/react` -> `emotionReact` and
-`@emotion/styled` -> `emotionStyled`. Minimum Node is now 18.18.
+- The styled-components peer dependency has been
+  replaced with @emotion/react and @emotion/styled (both ^11). Consumers
+  upgrading react-noti must uninstall styled-components (if it was only
+  installed for this library) and install the two @emotion packages.
+  The public component API (`<ReactNoti />`, `notify`, `POSITION`) is
+  unchanged. UMD bundle externals also rename: `styled-components` ->
+  `styled` becomes `@emotion/react` -> `emotionReact` and
+  `@emotion/styled` -> `emotionStyled`. Minimum Node is now 18.18.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,191 @@
+# Contributing to react-noti
+
+## Table of Contents
+
+- [Development setup](#development-setup)
+- [Project structure](#project-structure)
+- [Scripts](#scripts)
+- [Code style](#code-style)
+- [Commit convention](#commit-convention)
+- [Branch strategy](#branch-strategy)
+- [Opening a pull request](#opening-a-pull-request)
+- [Release process](#release-process)
+- [Demo deployment](#demo-deployment)
+
+---
+
+## Development setup
+
+**Requirements:** Node.js ≥ 18.18, npm ≥ 10.
+
+```bash
+git clone https://github.com/vitaliiburlaka/react-noti.git
+cd react-noti
+npm install
+npm start          # start the demo app at http://localhost:5173
+```
+
+---
+
+## Project structure
+
+```
+src/
+  components/
+    ReactNoti/     # container component — registers with notify singleton,
+    │              # manages toast list state, handles position ordering
+    Toast/         # individual toast — timer, dismiss, progress, icons
+  utils/
+    constants.ts   # POSITION, MSG_TYPE, defaultOptions
+    helpers.ts     # generateUID(), Timer class
+  styles/
+    colors.ts      # design token values (used as CSS variable fallbacks)
+    typography.ts
+    breakpoints.ts
+  notify.ts        # Notify singleton — store, configure, register, CRUD methods
+  index.ts         # public API surface
+  setupTests.ts    # Vitest + @testing-library/jest-dom setup
+
+examples/          # Vite demo app (not part of the published package)
+  src/
+  index.html
+  vite.config.ts
+
+dist/              # built library output (git-ignored)
+  react-noti.esm.js
+  react-noti.cjs.js
+  react-noti.esm.js.map
+  react-noti.cjs.js.map
+  src/index.d.ts
+```
+
+---
+
+## Scripts
+
+| Script                    | Description                                    |
+| ------------------------- | ---------------------------------------------- |
+| `npm start`               | Start demo app dev server                      |
+| `npm test`                | Run tests once                                 |
+| `npm run test:watch`      | Run tests in watch mode                        |
+| `npm run coverage`        | Run tests with v8 coverage report              |
+| `npm run build`           | Build the library (`dist/`)                    |
+| `npm run examples:build`  | Build the demo app (`examples/build/`)         |
+| `npm run typecheck`       | TypeScript type check (no emit)                |
+| `npm run lint`            | ESLint check                                   |
+| `npm run lint:fix`        | ESLint with auto-fix                           |
+| `npm run lint:format`     | Prettier check (md, json, yml, css)            |
+| `npm run lint:format:fix` | Prettier write (md, json, yml, css)            |
+| `npm run commit`          | Interactive conventional commit via Commitizen |
+
+**Before every commit, run:**
+
+```bash
+npm run lint:fix && npm run lint:format:fix
+```
+
+---
+
+## Code style
+
+- **ESLint** (`eslint.config.mjs`) — `typescript-eslint` recommended + React hooks rules + Prettier integration.
+- **Prettier** — enforced via `eslint-plugin-prettier`; also run directly on md/json/yml/css files.
+- **TypeScript** — strict mode, `moduleResolution: bundler`.
+- **Emotion** — all styles live in `*.styled.ts` files alongside their component. No inline `css` prop usage in component files.
+- **CSS custom properties** — design tokens are exposed as `--react-noti-*` variables in the styled files; `src/styles/colors.ts` holds the fallback values.
+
+---
+
+## Commit convention
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/) enforced by Commitizen. Always commit via:
+
+```bash
+npm run commit
+```
+
+Or match the format manually: `type(scope): subject`.
+
+| Type                                | When to use                       | Version bump |
+| ----------------------------------- | --------------------------------- | ------------ |
+| `feat`                              | New feature                       | minor        |
+| `fix`                               | Bug fix                           | patch        |
+| `perf`                              | Performance improvement           | patch        |
+| `refactor`                          | Refactor with no behaviour change | none         |
+| `test`                              | Tests only                        | none         |
+| `build`                             | Build system / tooling            | none         |
+| `ci`                                | CI configuration                  | none         |
+| `docs`                              | Documentation only                | none         |
+| `chore`                             | Housekeeping                      | none         |
+| `feat!` / `BREAKING CHANGE:` footer | Breaking change                   | **major**    |
+
+---
+
+## Branch strategy
+
+| Branch   | Purpose                 | Publishes to        |
+| -------- | ----------------------- | ------------------- |
+| `master` | Stable releases         | `latest` tag on npm |
+| `beta`   | Beta pre-releases       | `beta` tag on npm   |
+| `next`   | Next major pre-releases | `next` tag on npm   |
+| `alpha`  | Experimental            | `alpha` tag on npm  |
+
+Work happens in feature branches (`feat/`, `fix/`, `chore/`) off `master`. Open a PR to `master`.
+
+---
+
+## Opening a pull request
+
+1. Branch off `master`: `git checkout -b feat/your-feature`
+2. Make changes — keep scope focused; one concern per PR.
+3. Run the full check suite locally:
+   ```bash
+   npm run lint:fix && npm run lint:format:fix
+   npm run typecheck
+   npm test
+   npm run build
+   ```
+4. If the change touches Emotion styled components, run `npm start` and visually verify in a browser — lint/tsc/test passing does not prove CSS-in-JS renders correctly.
+5. Commit using `npm run commit`.
+6. Push and open a PR against `master`.
+
+---
+
+## Release process
+
+Releases are fully automated via [semantic-release](https://semantic-release.gitbook.io/) and triggered by CI on every push to `master`.
+
+semantic-release will:
+
+1. Analyse commits since the last release.
+2. Determine the next version based on commit types (see table above).
+3. Update `CHANGELOG.md` and `package.json`.
+4. Publish to npm.
+5. Create a GitHub Release with release notes.
+6. Commit the version bump back to `master` (commit message: `chore(release): x.y.z [skip ci]`).
+
+**Nothing needs to be done manually.** Merging a PR to `master` is the release trigger.
+
+---
+
+## Demo deployment
+
+The demo at <https://vitaliiburlaka.github.io/react-noti> is deployed automatically to GitHub Pages after every successful release on `master`.
+
+### How it works
+
+The `deploy` job in `.github/workflows/ci.yml` runs after `release` completes. It:
+
+1. Builds the demo app (`npm run examples:build` → `examples/build/`).
+2. Uploads the build as a GitHub Pages artifact.
+3. Deploys via the native `actions/deploy-pages` action.
+
+### One-time repository setup
+
+The native GitHub Actions deployment method requires a single setting change in the repository (done once by the maintainer, not tracked in code):
+
+> **Settings → Pages → Build and deployment → Source → select "GitHub Actions"**
+
+This switches GitHub Pages away from the legacy branch-based model (where you commit built files to a `gh-pages` branch) to the modern artifact-based model used by `actions/deploy-pages`. Without this setting the deploy job will fail with a permissions error.
+
+The `Vite` demo config (`examples/vite.config.ts`) already sets `base: '/react-noti/'` so asset paths resolve correctly under the Pages subdirectory.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
   - [`ReactNoti` container](#reactnoti-container)
   - [`notify` toast options](#notify-toast-options)
     - [Optional `notify` methods parameters](#optional-notify-methods-parameters)
+- [Customization](#customization)
+  - [CSS custom properties](#css-custom-properties)
+  - [className props](#classname-props)
 - [TypeScript types](#typescript-types)
 - [License](#license)
 
@@ -136,6 +139,7 @@ export default App
 | `pauseOnHover` | `boolean` | `true`        | ✘        | Pause the dismiss timer while the cursor is over a toast. |
 | `showProgress` | `boolean` | `true`        | ✘        | Show a progress bar counting down to dismiss. |
 | `className`    | `string`  | `undefined`   | ✘        | Extra CSS class added to the container element. |
+| `classNames`   | `NotiClassNames` | `undefined` | ✘   | Per-slot CSS classes for toast internals (see [Customization](#customization)). |
 
 ### `notify` toast options
 
@@ -172,6 +176,76 @@ notify.error('Something failed', { title: 'Error', pauseOnHover: false })
 notify.closeAll()
 ```
 
+## Customization
+
+### CSS custom properties
+
+All design tokens are exposed as CSS custom properties. Override them in plain CSS — no Emotion knowledge required.
+
+```css
+/* global */
+:root {
+  --noti-bg-success: #1a7f4b;
+  --noti-bg-error:   #9c1c1c;
+  --noti-radius:     8px;
+}
+
+/* scoped to part of your app */
+.dark-theme {
+  --noti-bg-success: #1a7f4b;
+  --noti-color:      #f0f0f0;
+}
+```
+
+<!-- prettier-ignore-start -->
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `--noti-color` | `#1e1f20` | Toast text colour |
+| `--noti-bg-success` | `#daf5e5` | Success toast background |
+| `--noti-bg-info` | `#d9eaf1` | Info toast background |
+| `--noti-bg-warning` | `#fff0de` | Warning toast background |
+| `--noti-bg-error` | `#ffe7e2` | Error toast background |
+| `--noti-progress-success` | `#8adfad` | Success progress bar colour |
+| `--noti-progress-info` | `#8ec1d6` | Info progress bar colour |
+| `--noti-progress-warning` | `#ffc278` | Warning progress bar colour |
+| `--noti-progress-error` | `#ff937c` | Error progress bar colour |
+| `--noti-radius` | `4px` | Toast border-radius |
+| `--noti-shadow` | `0 3px 9px rgba(0,0,0,.175)` | Toast box-shadow |
+| `--noti-font-family` | `'Open Sans', sans-serif` | Font family |
+| `--noti-font-size` | `14px` | Toast body font size |
+| `--noti-z-index` | `4000` | Tray stacking order |
+<!-- prettier-ignore-end -->
+
+### className props
+
+Apply your own CSS classes to the container or every toast:
+
+```tsx
+<ReactNoti
+  className="my-container"
+  classNames={{
+    toast:    'my-toast',
+    body:     'my-body',
+    title:    'my-title',
+    content:  'my-content',
+    dismiss:  'my-dismiss',
+    progress: 'my-progress',
+  }}
+/>
+```
+
+<!-- prettier-ignore-start -->
+| Prop | Slot |
+| ---- | ---- |
+| `className` | Root wrapper `<div>` |
+| `classNames.toast` | Individual toast element |
+| `classNames.body` | Toast body (text area) |
+| `classNames.title` | Toast title `<strong>` |
+| `classNames.content` | Toast content `<section>` |
+| `classNames.dismiss` | Dismiss button |
+| `classNames.progress` | Progress bar |
+<!-- prettier-ignore-end -->
+
 ## TypeScript types
 
 All public types are exported from `react-noti`:
@@ -184,6 +258,7 @@ import type {
   ToastItem,      // Shape of a toast in the internal store
   NotifyConfig,   // Shape of the global notify configuration
   RegisterOptions,// Argument to notify.register()
+  NotiClassNames, // Slot class names for ReactNoti classNames prop
   ToastType,      // Alias for MsgType (deprecated — prefer MsgType)
 } from 'react-noti'
 ```

--- a/README.md
+++ b/README.md
@@ -114,9 +114,17 @@ function App() {
       <ReactNoti position={POSITION.TOP_RIGHT} />
 
       <button onClick={() => notify.success('Done!')}>Success</button>
-      <button onClick={() => notify.info('FYI', { title: 'Note' })}>Info</button>
-      <button onClick={() => notify.warning('Be careful', { autoDismiss: false })}>Warning</button>
-      <button onClick={() => notify.error('Oops', { timeOut: 9000 })}>Error</button>
+      <button onClick={() => notify.info('FYI', { title: 'Note' })}>
+        Info
+      </button>
+      <button
+        onClick={() => notify.warning('Be careful', { autoDismiss: false })}
+      >
+        Warning
+      </button>
+      <button onClick={() => notify.error('Oops', { timeOut: 9000 })}>
+        Error
+      </button>
     </div>
   )
 }
@@ -164,7 +172,9 @@ export default App
 ```tsx
 // Pass a React element as content
 const Avatar = ({ src }: { src: string }) => (
-  <span><img width={48} src={src} alt="" /></span>
+  <span>
+    <img width={48} src={src} alt="" />
+  </span>
 )
 
 notify.success('Plain text toast')
@@ -186,14 +196,14 @@ All design tokens are exposed as CSS custom properties. Override them in plain C
 /* global */
 :root {
   --react-noti-bg-success: #1a7f4b;
-  --react-noti-bg-error:   #9c1c1c;
-  --react-noti-radius:     8px;
+  --react-noti-bg-error: #9c1c1c;
+  --react-noti-radius: 8px;
 }
 
 /* scoped to part of your app */
 .dark-theme {
   --react-noti-bg-success: #1a7f4b;
-  --react-noti-color:      #f0f0f0;
+  --react-noti-color: #f0f0f0;
 }
 ```
 
@@ -224,11 +234,11 @@ Apply your own CSS classes to the container or every toast:
 <ReactNoti
   className="my-container"
   classNames={{
-    toast:    'my-toast',
-    body:     'my-body',
-    title:    'my-title',
-    content:  'my-content',
-    dismiss:  'my-dismiss',
+    toast: 'my-toast',
+    body: 'my-body',
+    title: 'my-title',
+    content: 'my-content',
+    dismiss: 'my-dismiss',
     progress: 'my-progress',
   }}
 />
@@ -252,14 +262,14 @@ All public types are exported from `react-noti`:
 
 ```ts
 import type {
-  Position,       // Union of all valid position strings
-  MsgType,        // 'success' | 'info' | 'warning' | 'error'
-  ToastOptions,   // Per-toast option overrides
-  ToastItem,      // Shape of a toast in the internal store
-  NotifyConfig,   // Shape of the global notify configuration
-  RegisterOptions,// Argument to notify.register()
+  Position, // Union of all valid position strings
+  MsgType, // 'success' | 'info' | 'warning' | 'error'
+  ToastOptions, // Per-toast option overrides
+  ToastItem, // Shape of a toast in the internal store
+  NotifyConfig, // Shape of the global notify configuration
+  RegisterOptions, // Argument to notify.register()
   NotiClassNames, // Slot class names for ReactNoti classNames prop
-  ToastType,      // Alias for MsgType (deprecated — prefer MsgType)
+  ToastType, // Alias for MsgType (deprecated — prefer MsgType)
 } from 'react-noti'
 ```
 
@@ -276,11 +286,7 @@ interface ToastButtonProps {
 }
 
 function ToastButton({ type, message, options }: ToastButtonProps) {
-  return (
-    <button onClick={() => notify[type](message, options)}>
-      {type}
-    </button>
-  )
+  return <button onClick={() => notify[type](message, options)}>{type}</button>
 }
 
 // Position values are strongly typed

--- a/README.md
+++ b/README.md
@@ -185,35 +185,35 @@ All design tokens are exposed as CSS custom properties. Override them in plain C
 ```css
 /* global */
 :root {
-  --noti-bg-success: #1a7f4b;
-  --noti-bg-error:   #9c1c1c;
-  --noti-radius:     8px;
+  --react-noti-bg-success: #1a7f4b;
+  --react-noti-bg-error:   #9c1c1c;
+  --react-noti-radius:     8px;
 }
 
 /* scoped to part of your app */
 .dark-theme {
-  --noti-bg-success: #1a7f4b;
-  --noti-color:      #f0f0f0;
+  --react-noti-bg-success: #1a7f4b;
+  --react-noti-color:      #f0f0f0;
 }
 ```
 
 <!-- prettier-ignore-start -->
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `--noti-color` | `#1e1f20` | Toast text colour |
-| `--noti-bg-success` | `#daf5e5` | Success toast background |
-| `--noti-bg-info` | `#d9eaf1` | Info toast background |
-| `--noti-bg-warning` | `#fff0de` | Warning toast background |
-| `--noti-bg-error` | `#ffe7e2` | Error toast background |
-| `--noti-progress-success` | `#8adfad` | Success progress bar colour |
-| `--noti-progress-info` | `#8ec1d6` | Info progress bar colour |
-| `--noti-progress-warning` | `#ffc278` | Warning progress bar colour |
-| `--noti-progress-error` | `#ff937c` | Error progress bar colour |
-| `--noti-radius` | `4px` | Toast border-radius |
-| `--noti-shadow` | `0 3px 9px rgba(0,0,0,.175)` | Toast box-shadow |
-| `--noti-font-family` | `'Open Sans', sans-serif` | Font family |
-| `--noti-font-size` | `14px` | Toast body font size |
-| `--noti-z-index` | `4000` | Tray stacking order |
+| `--react-noti-color` | `#1e1f20` | Toast text colour |
+| `--react-noti-bg-success` | `#daf5e5` | Success toast background |
+| `--react-noti-bg-info` | `#d9eaf1` | Info toast background |
+| `--react-noti-bg-warning` | `#fff0de` | Warning toast background |
+| `--react-noti-bg-error` | `#ffe7e2` | Error toast background |
+| `--react-noti-progress-success` | `#8adfad` | Success progress bar colour |
+| `--react-noti-progress-info` | `#8ec1d6` | Info progress bar colour |
+| `--react-noti-progress-warning` | `#ffc278` | Warning progress bar colour |
+| `--react-noti-progress-error` | `#ff937c` | Error progress bar colour |
+| `--react-noti-radius` | `4px` | Toast border-radius |
+| `--react-noti-shadow` | `0 3px 9px rgba(0,0,0,.175)` | Toast box-shadow |
+| `--react-noti-font-family` | `'Open Sans', sans-serif` | Font family |
+| `--react-noti-font-size` | `14px` | Toast body font size |
+| `--react-noti-z-index` | `4000` | Tray stacking order |
 <!-- prettier-ignore-end -->
 
 ### className props

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ import type {
   ToastItem, // Shape of a toast in the internal store
   NotifyConfig, // Shape of the global notify configuration
   RegisterOptions, // Argument to notify.register()
+  ReactNotiProps, // Props for the ReactNoti container component
   NotiClassNames, // Slot class names for ReactNoti classNames prop
   ToastType, // Alias for MsgType (deprecated — prefer MsgType)
 } from 'react-noti'

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "main": "dist/react-noti.cjs.js",
   "module": "dist/react-noti.esm.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/react-noti.esm.js",
+      "require": "./dist/react-noti.cjs.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "sideEffects": false,
   "scripts": {
     "start": "vite --config examples/vite.config.ts",
     "test": "vitest run",
@@ -94,8 +102,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.0.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
@@ -108,17 +115,11 @@
       "doctoc --maxlevel 4 --notitle"
     ]
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "npm run coverage"
-    }
-  },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "last 2 years",
+      ">0.5%",
+      "not dead"
     ],
     "development": [
       "last 1 chrome version",

--- a/src/components/ReactNoti/ReactNoti.styled.ts
+++ b/src/components/ReactNoti/ReactNoti.styled.ts
@@ -4,7 +4,7 @@ import { css, type SerializedStyles } from '@emotion/react'
 import typography from '../../styles/typography'
 import breakpoints from '../../styles/breakpoints'
 import colors from '../../styles/colors'
-import { POSITION } from '../../utils/constants'
+import { POSITION, type Position } from '../../utils/constants'
 
 export const StyledReactNoti = styled.div`
   font-family: var(--react-noti-font-family, ${typography.fontFamily});
@@ -18,9 +18,7 @@ export const StyledReactNoti = styled.div`
   }
 `
 
-type PositionType = (typeof POSITION)[keyof typeof POSITION]
-
-function getPositionStyles(position?: PositionType): SerializedStyles | null {
+function getPositionStyles(position?: Position): SerializedStyles | null {
   switch (position) {
     case POSITION.TOP_CENTER:
       return css`
@@ -76,7 +74,7 @@ function getPositionStyles(position?: PositionType): SerializedStyles | null {
 }
 
 interface StyledTrayProps {
-  position?: PositionType
+  position?: Position
 }
 
 export const StyledTray = styled('div', {

--- a/src/components/ReactNoti/ReactNoti.styled.ts
+++ b/src/components/ReactNoti/ReactNoti.styled.ts
@@ -7,7 +7,7 @@ import colors from '../../styles/colors'
 import { POSITION } from '../../utils/constants'
 
 export const StyledReactNoti = styled.div`
-  font-family: ${typography.fontFamily};
+  font-family: var(--noti-font-family, ${typography.fontFamily});
   font-weight: ${typography.fontWeight};
   line-height: ${typography.lineHeight};
 
@@ -85,11 +85,11 @@ export const StyledTray = styled('div', {
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-  color: ${colors.primary};
+  color: var(--noti-color, ${colors.primary});
   text-align: left;
   padding: 8px;
   width: calc(100% - 32px);
-  z-index: 4000;
+  z-index: var(--noti-z-index, 4000);
 
   @media screen and (min-width: ${breakpoints.medium}px) {
     width: 360px;

--- a/src/components/ReactNoti/ReactNoti.styled.ts
+++ b/src/components/ReactNoti/ReactNoti.styled.ts
@@ -7,7 +7,7 @@ import colors from '../../styles/colors'
 import { POSITION } from '../../utils/constants'
 
 export const StyledReactNoti = styled.div`
-  font-family: var(--noti-font-family, ${typography.fontFamily});
+  font-family: var(--react-noti-font-family, ${typography.fontFamily});
   font-weight: ${typography.fontWeight};
   line-height: ${typography.lineHeight};
 
@@ -85,11 +85,11 @@ export const StyledTray = styled('div', {
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-  color: var(--noti-color, ${colors.primary});
+  color: var(--react-noti-color, ${colors.primary});
   text-align: left;
   padding: 8px;
   width: calc(100% - 32px);
-  z-index: var(--noti-z-index, 4000);
+  z-index: var(--react-noti-z-index, 4000);
 
   @media screen and (min-width: ${breakpoints.medium}px) {
     width: 360px;

--- a/src/components/ReactNoti/ReactNoti.test.tsx
+++ b/src/components/ReactNoti/ReactNoti.test.tsx
@@ -40,7 +40,7 @@ describe('<ReactNoti />', () => {
       notify.success(MSG_TYPE.INFO)
     })
 
-    const [firstToast] = getAllByTestId('noti-toast')
+    const [firstToast] = getAllByTestId('react-noti-toast')
     expect(firstToast.querySelector('section')?.textContent).toEqual(
       MSG_TYPE.INFO
     )

--- a/src/components/ReactNoti/ReactNoti.test.tsx
+++ b/src/components/ReactNoti/ReactNoti.test.tsx
@@ -40,7 +40,7 @@ describe('<ReactNoti />', () => {
       notify.success(MSG_TYPE.INFO)
     })
 
-    const [firstToast] = getAllByTestId('ReactNoti-Toast')
+    const [firstToast] = getAllByTestId('noti-toast')
     expect(firstToast.querySelector('section')?.textContent).toEqual(
       MSG_TYPE.INFO
     )

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -5,7 +5,7 @@ import notify, { type ToastItem } from '../../notify'
 import { defaultOptions, type Position } from '../../utils/constants'
 import { StyledReactNoti, StyledTray } from './ReactNoti.styled'
 
-interface ReactNotiProps {
+export interface ReactNotiProps {
   position?: Position
   autoDismiss?: boolean
   timeOut?: number

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -56,7 +56,11 @@ export function ReactNoti({
   }, [handleStoreChange])
 
   return (
-    <StyledReactNoti className={className}>
+    <StyledReactNoti
+      className={className}
+      aria-live="polite"
+      aria-atomic="false"
+    >
       {toasts.length > 0 && (
         <StyledTray position={position}>
           {toasts.map((t) => (

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -41,18 +41,18 @@ export function ReactNoti({
     [position]
   )
 
-  notify.configure({
-    autoDismiss,
-    timeOut,
-    single,
-    pauseOnHover,
-    showProgress,
-  })
+  useEffect(() => {
+    notify.configure({
+      autoDismiss,
+      timeOut,
+      single,
+      pauseOnHover,
+      showProgress,
+    })
+  }, [autoDismiss, timeOut, single, pauseOnHover, showProgress])
 
   useEffect(() => {
-    notify.register({
-      handleStoreChange,
-    })
+    notify.register({ handleStoreChange })
   }, [handleStoreChange])
 
   return (

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import Toast, { type NotiClassNames } from '../Toast'
 import notify, { type ToastItem } from '../../notify'
@@ -30,13 +30,16 @@ export function ReactNoti({
 }: ReactNotiProps) {
   const [toasts, setToasts] = useState<ToastItem[]>([])
 
-  const handleStoreChange = (newToasts: ToastItem[]) => {
-    const [pos] = position.split('-')
-    const nextToasts =
-      pos === 'bottom' ? [...newToasts].reverse() : [...newToasts]
+  const handleStoreChange = useCallback(
+    (newToasts: ToastItem[]) => {
+      const [pos] = position.split('-')
+      const nextToasts =
+        pos === 'bottom' ? [...newToasts].reverse() : [...newToasts]
 
-    setToasts(nextToasts)
-  }
+      setToasts(nextToasts)
+    },
+    [position]
+  )
 
   notify.configure({
     autoDismiss,
@@ -50,8 +53,7 @@ export function ReactNoti({
     notify.register({
       handleStoreChange,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [handleStoreChange])
 
   return (
     <StyledReactNoti className={className}>

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import Toast from '../Toast'
+import Toast, { type NotiClassNames } from '../Toast'
 import notify, { type ToastItem } from '../../notify'
 import { defaultOptions, type Position } from '../../utils/constants'
 import { StyledReactNoti, StyledTray } from './ReactNoti.styled'
@@ -14,6 +14,7 @@ interface ReactNotiProps {
   pauseOnHover?: boolean
   showProgress?: boolean
   className?: string
+  classNames?: NotiClassNames
 }
 
 export function ReactNoti({
@@ -25,11 +26,9 @@ export function ReactNoti({
   pauseOnHover = defaultOptions.pauseOnHover,
   showProgress = defaultOptions.showProgress,
   className,
+  classNames,
 }: ReactNotiProps) {
   const [toasts, setToasts] = useState<ToastItem[]>([])
-  // TODO: Remove class names in a future major; obsolete now that styles come from emotion.
-  const cls = `ReactNoti ${className || ''}`.trim()
-  const trayCls = `ReactNoti__Tray ReactNoti__Tray--${position}`
 
   const handleStoreChange = (newToasts: ToastItem[]) => {
     const [pos] = position.split('-')
@@ -55,9 +54,9 @@ export function ReactNoti({
   }, [])
 
   return (
-    <StyledReactNoti className={cls}>
+    <StyledReactNoti className={className}>
       {toasts.length > 0 && (
-        <StyledTray className={trayCls} position={position}>
+        <StyledTray position={position}>
           {toasts.map((t) => (
             <Toast
               key={t.id}
@@ -71,6 +70,7 @@ export function ReactNoti({
               pauseOnHover={t.pauseOnHover}
               showProgress={showProgress}
               onDismiss={notify.dismiss}
+              classNames={classNames}
             />
           ))}
         </StyledTray>

--- a/src/components/ReactNoti/index.ts
+++ b/src/components/ReactNoti/index.ts
@@ -1,3 +1,4 @@
 import ReactNoti from './ReactNoti'
 
 export default ReactNoti
+export type { ReactNotiProps } from './ReactNoti'

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -24,12 +24,12 @@ export const StyledToast = styled('div', {
   width: 100%;
   min-height: 48px;
   max-height: 600px;
-  color: var(--noti-color, ${colors.primary});
+  color: var(--react-noti-color, ${colors.primary});
   background-color: ${({ type }) =>
-    type ? `var(--noti-bg-${type}, ${colors[type]})` : '#fff'};
-  border-radius: var(--noti-radius, 4px);
+    type ? `var(--react-noti-bg-${type}, ${colors[type]})` : '#fff'};
+  border-radius: var(--react-noti-radius, 4px);
   overflow: hidden;
-  box-shadow: var(--noti-shadow, 0 3px 9px rgba(0, 0, 0, 0.175));
+  box-shadow: var(--react-noti-shadow, 0 3px 9px rgba(0, 0, 0, 0.175));
 
   /* IE 11 min-height bug workaround */
   @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
@@ -70,7 +70,7 @@ export const StyledBody = styled('div', {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  font-size: var(--noti-font-size, 14px);
+  font-size: var(--react-noti-font-size, 14px);
   font-weight: 200;
   padding: ${({ icons }) => (icons ? '8px' : '8px 12px')};
   margin-right: 22px;
@@ -119,6 +119,6 @@ export const StyledProgress = styled('div', {
   height: 4px;
   width: 100%;
   background-color: ${({ kind }) =>
-    kind ? `var(--noti-progress-${kind}, ${colors[`${kind}Dark`]})` : '#fff'};
+    kind ? `var(--react-noti-progress-${kind}, ${colors[`${kind}Dark`]})` : '#fff'};
   animation: ${rnShrinkWidth} ${({ duration }) => duration}ms linear;
 `

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -24,11 +24,12 @@ export const StyledToast = styled('div', {
   width: 100%;
   min-height: 48px;
   max-height: 600px;
-  color: ${colors.primary};
-  background-color: ${({ type }) => (type ? colors[type] : '#fff')};
-  border-radius: 4px;
+  color: var(--noti-color, ${colors.primary});
+  background-color: ${({ type }) =>
+    type ? `var(--noti-bg-${type}, ${colors[type]})` : '#fff'};
+  border-radius: var(--noti-radius, 4px);
   overflow: hidden;
-  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.175);
+  box-shadow: var(--noti-shadow, 0 3px 9px rgba(0, 0, 0, 0.175));
 
   /* IE 11 min-height bug workaround */
   @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
@@ -69,7 +70,7 @@ export const StyledBody = styled('div', {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  font-size: 14px;
+  font-size: var(--noti-font-size, 14px);
   font-weight: 200;
   padding: ${({ icons }) => (icons ? '8px' : '8px 12px')};
   margin-right: 22px;
@@ -117,6 +118,7 @@ export const StyledProgress = styled('div', {
   left: 0;
   height: 4px;
   width: 100%;
-  background-color: ${({ kind }) => (kind ? colors[`${kind}Dark`] : '#fff')};
+  background-color: ${({ kind }) =>
+    kind ? `var(--noti-progress-${kind}, ${colors[`${kind}Dark`]})` : '#fff'};
   animation: ${rnShrinkWidth} ${({ duration }) => duration}ms linear;
 `

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -119,6 +119,8 @@ export const StyledProgress = styled('div', {
   height: 4px;
   width: 100%;
   background-color: ${({ kind }) =>
-    kind ? `var(--react-noti-progress-${kind}, ${colors[`${kind}Dark`]})` : '#fff'};
+    kind
+      ? `var(--react-noti-progress-${kind}, ${colors[`${kind}Dark`]})`
+      : '#fff'};
   animation: ${rnShrinkWidth} ${({ duration }) => duration}ms linear;
 `

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -31,14 +31,6 @@ export const StyledToast = styled('div', {
   overflow: hidden;
   box-shadow: var(--react-noti-shadow, 0 3px 9px rgba(0, 0, 0, 0.175));
 
-  /* IE 11 min-height bug workaround */
-  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    &::after {
-      content: '';
-      min-height: inherit;
-    }
-  }
-
   &:not(:last-child) {
     margin-bottom: 8px;
   }

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -123,20 +123,39 @@ describe('<Toast />', () => {
     expect(onDismissMockFn).toHaveBeenCalled()
   })
 
-  it('should dismiss Toast when mouse hovered if pauseOnHover is FALSE', () => {
+  it('should dismiss Toast on hover when pauseOnHover is FALSE', () => {
     const onDismissMockFn = vi.fn()
     const props = {
       ...defaultProps,
       pauseOnHover: false,
       onDismiss: onDismissMockFn,
     }
-    const { getByTestId } = render(<Toast {...props} />)
+    render(<Toast {...props} />)
 
-    fireEvent.mouseEnter(getByTestId('react-noti-toast'))
-    vi.runOnlyPendingTimers()
-    fireEvent.mouseLeave(getByTestId('react-noti-toast'))
+    // Timer is not paused on hover, so it fires after the first runOnlyPendingTimers
+    fireEvent.mouseEnter(
+      document.querySelector('[data-testid="react-noti-toast"]')!
+    )
     vi.runOnlyPendingTimers()
 
-    expect(onDismissMockFn).toHaveBeenCalled()
+    expect(onDismissMockFn).toHaveBeenCalledWith(props.id)
+  })
+
+  it('should apply classNames to toast slots', () => {
+    const props = {
+      ...defaultProps,
+      classNames: {
+        toast: 'custom-toast',
+        body: 'custom-body',
+        dismiss: 'custom-dismiss',
+        progress: 'custom-progress',
+      },
+    }
+    const { container } = render(<Toast {...props} />)
+
+    expect(container.querySelector('.custom-toast')).toBeInTheDocument()
+    expect(container.querySelector('.custom-body')).toBeInTheDocument()
+    expect(container.querySelector('.custom-dismiss')).toBeInTheDocument()
+    expect(container.querySelector('.custom-progress')).toBeInTheDocument()
   })
 })

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -36,7 +36,7 @@ describe('<Toast />', () => {
 
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.click(getByTestId('noti-dismiss'))
+    fireEvent.click(getByTestId('react-noti-dismiss'))
 
     vi.runOnlyPendingTimers()
 
@@ -88,7 +88,7 @@ describe('<Toast />', () => {
 
     const { getByTestId } = render(<Toast {...props} />)
 
-    expect(getByTestId('noti-progress')).toBeInTheDocument()
+    expect(getByTestId('react-noti-progress')).toBeInTheDocument()
   })
 
   it('should not dismiss Toast when mouse hovered on', () => {
@@ -100,7 +100,7 @@ describe('<Toast />', () => {
     }
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.mouseEnter(getByTestId('noti-toast'))
+    fireEvent.mouseEnter(getByTestId('react-noti-toast'))
     vi.runOnlyPendingTimers()
 
     expect(onDismissMockFn).not.toHaveBeenCalled()
@@ -115,9 +115,9 @@ describe('<Toast />', () => {
     }
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.mouseEnter(getByTestId('noti-toast'))
+    fireEvent.mouseEnter(getByTestId('react-noti-toast'))
     vi.runOnlyPendingTimers()
-    fireEvent.mouseLeave(getByTestId('noti-toast'))
+    fireEvent.mouseLeave(getByTestId('react-noti-toast'))
     vi.runOnlyPendingTimers()
 
     expect(onDismissMockFn).toHaveBeenCalled()
@@ -132,9 +132,9 @@ describe('<Toast />', () => {
     }
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.mouseEnter(getByTestId('noti-toast'))
+    fireEvent.mouseEnter(getByTestId('react-noti-toast'))
     vi.runOnlyPendingTimers()
-    fireEvent.mouseLeave(getByTestId('noti-toast'))
+    fireEvent.mouseLeave(getByTestId('react-noti-toast'))
     vi.runOnlyPendingTimers()
 
     expect(onDismissMockFn).toHaveBeenCalled()

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -36,7 +36,7 @@ describe('<Toast />', () => {
 
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.click(getByTestId('btn-dismiss'))
+    fireEvent.click(getByTestId('noti-dismiss'))
 
     vi.runOnlyPendingTimers()
 
@@ -88,7 +88,7 @@ describe('<Toast />', () => {
 
     const { getByTestId } = render(<Toast {...props} />)
 
-    expect(getByTestId('ReactNoti-Toast-progress')).toBeInTheDocument()
+    expect(getByTestId('noti-progress')).toBeInTheDocument()
   })
 
   it('should not dismiss Toast when mouse hovered on', () => {
@@ -100,7 +100,7 @@ describe('<Toast />', () => {
     }
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.mouseEnter(getByTestId('ReactNoti-Toast'))
+    fireEvent.mouseEnter(getByTestId('noti-toast'))
     vi.runOnlyPendingTimers()
 
     expect(onDismissMockFn).not.toHaveBeenCalled()
@@ -115,9 +115,9 @@ describe('<Toast />', () => {
     }
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.mouseEnter(getByTestId('ReactNoti-Toast'))
+    fireEvent.mouseEnter(getByTestId('noti-toast'))
     vi.runOnlyPendingTimers()
-    fireEvent.mouseLeave(getByTestId('ReactNoti-Toast'))
+    fireEvent.mouseLeave(getByTestId('noti-toast'))
     vi.runOnlyPendingTimers()
 
     expect(onDismissMockFn).toHaveBeenCalled()
@@ -132,9 +132,9 @@ describe('<Toast />', () => {
     }
     const { getByTestId } = render(<Toast {...props} />)
 
-    fireEvent.mouseEnter(getByTestId('ReactNoti-Toast'))
+    fireEvent.mouseEnter(getByTestId('noti-toast'))
     vi.runOnlyPendingTimers()
-    fireEvent.mouseLeave(getByTestId('ReactNoti-Toast'))
+    fireEvent.mouseLeave(getByTestId('noti-toast'))
     vi.runOnlyPendingTimers()
 
     expect(onDismissMockFn).toHaveBeenCalled()

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -2,6 +2,7 @@ import {
   useEffect,
   useState,
   useRef,
+  memo,
   type ReactNode,
   type ReactElement,
 } from 'react'
@@ -148,4 +149,4 @@ function Toast({
   )
 }
 
-export default Toast
+export default memo(Toast)

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -109,7 +109,7 @@ function Toast({
   return (
     <StyledToast
       className={classNames.toast}
-      data-testid="noti-toast"
+      data-testid="react-noti-toast"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       type={type}
@@ -129,7 +129,7 @@ function Toast({
         className={classNames.dismiss}
         type="button"
         onClick={handleDismiss}
-        data-testid="noti-dismiss"
+        data-testid="react-noti-dismiss"
       >
         <StyledIcon />
       </StyledBtnDismiss>
@@ -137,7 +137,7 @@ function Toast({
       {autoDismiss && showProgress === true && (
         <StyledProgress
           className={classNames.progress}
-          data-testid="noti-progress"
+          data-testid="react-noti-progress"
           kind={type}
           duration={timeOut}
           style={{

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -30,6 +30,15 @@ const iconsMap: Record<MsgType, ReactElement> = {
   error: <ErrorIcon />,
 }
 
+export interface NotiClassNames {
+  toast?: string
+  body?: string
+  title?: string
+  content?: string
+  dismiss?: string
+  progress?: string
+}
+
 interface ToastProps {
   id: string
   content: ReactNode
@@ -41,6 +50,7 @@ interface ToastProps {
   icons: boolean
   pauseOnHover: boolean
   showProgress: boolean
+  classNames?: NotiClassNames
 }
 
 function Toast({
@@ -54,14 +64,10 @@ function Toast({
   icons,
   pauseOnHover,
   showProgress,
+  classNames = {},
 }: ToastProps) {
   const timer = useRef<Timer | null>(null)
   const [isRunning, setIsRunning] = useState(autoDismiss)
-  // TODO: Remove class names in a future major; obsolete now that styles come from emotion.
-  const cls = `ReactNoti__Toast ReactNoti__Toast--${type}`
-  const bodyCls = `ReactNoti__Toast__body ${!icons ? 'no-icon' : ''}`.trim()
-  const typeIconCls = `RN-icon icon-${type}`
-  const progressCls = `ReactNoti__Toast__progress ReactNoti__Toast__progress--${type}`
 
   const handleDismiss = () => {
     onDismiss(id)
@@ -101,39 +107,35 @@ function Toast({
 
   return (
     <StyledToast
-      className={cls}
+      className={classNames.toast}
       data-testid="ReactNoti-Toast"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       type={type}
     >
       {icons && (
-        <StyledType
-          className="ReactNoti__Toast__type"
-          role="img"
-          aria-label={`alert ${type}`}
-        >
-          <StyledIcon className={typeIconCls}>{iconsMap[type]}</StyledIcon>
+        <StyledType role="img" aria-label={`alert ${type}`}>
+          <StyledIcon>{iconsMap[type]}</StyledIcon>
         </StyledType>
       )}
 
-      <StyledBody className={bodyCls} icons={icons}>
-        {title && <strong className="ReactNoti__Toast__title">{title}</strong>}
-        <section className="ReactNoti__Toast__content">{content}</section>
+      <StyledBody className={classNames.body} icons={icons}>
+        {title && <strong className={classNames.title}>{title}</strong>}
+        <section className={classNames.content}>{content}</section>
       </StyledBody>
 
       <StyledBtnDismiss
-        className="ReactNoti__Toast__btn-dismiss"
+        className={classNames.dismiss}
         type="button"
         onClick={handleDismiss}
         data-testid="btn-dismiss"
       >
-        <StyledIcon className="RN-icon icon-close" />
+        <StyledIcon />
       </StyledBtnDismiss>
 
       {autoDismiss && showProgress === true && (
         <StyledProgress
-          className={progressCls}
+          className={classNames.progress}
           data-testid="ReactNoti-Toast-progress"
           kind={type}
           duration={timeOut}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -109,7 +109,7 @@ function Toast({
   return (
     <StyledToast
       className={classNames.toast}
-      data-testid="ReactNoti-Toast"
+      data-testid="noti-toast"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       type={type}
@@ -129,7 +129,7 @@ function Toast({
         className={classNames.dismiss}
         type="button"
         onClick={handleDismiss}
-        data-testid="btn-dismiss"
+        data-testid="noti-dismiss"
       >
         <StyledIcon />
       </StyledBtnDismiss>
@@ -137,7 +137,7 @@ function Toast({
       {autoDismiss && showProgress === true && (
         <StyledProgress
           className={classNames.progress}
-          data-testid="ReactNoti-Toast-progress"
+          data-testid="noti-progress"
           kind={type}
           duration={timeOut}
           style={{

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -116,7 +116,7 @@ function Toast({
     >
       {icons && (
         <StyledType role="img" aria-label={`alert ${type}`}>
-          <StyledIcon>{iconsMap[type]}</StyledIcon>
+          <StyledIcon aria-hidden="true">{iconsMap[type]}</StyledIcon>
         </StyledType>
       )}
 
@@ -128,10 +128,11 @@ function Toast({
       <StyledBtnDismiss
         className={classNames.dismiss}
         type="button"
+        aria-label="Dismiss notification"
         onClick={handleDismiss}
         data-testid="react-noti-dismiss"
       >
-        <StyledIcon />
+        <StyledIcon aria-hidden="true" />
       </StyledBtnDismiss>
 
       {autoDismiss && showProgress === true && (

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,3 +1,4 @@
 import Toast from './Toast'
 
 export default Toast
+export type { NotiClassNames } from './Toast'

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export type {
   NotifyConfig,
   RegisterOptions,
 } from './notify'
+export type { NotiClassNames } from './components/Toast'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import notify from './notify'
-import { POSITION } from './utils/constants'
+import { POSITION, MSG_TYPE } from './utils/constants'
 import ReactNoti from './components/ReactNoti'
 
-export { ReactNoti, notify, POSITION }
+export { ReactNoti, notify, POSITION, MSG_TYPE }
 export type { MsgType, Position } from './utils/constants'
 export type {
   ToastType,
@@ -12,3 +12,4 @@ export type {
   RegisterOptions,
 } from './notify'
 export type { NotiClassNames } from './components/Toast'
+export type { ReactNotiProps } from './components/ReactNoti'

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -104,4 +104,26 @@ describe('notify', () => {
       expect.objectContaining({ id: 'aaa-bbb' }),
     ])
   })
+
+  it('should clear all toasts and call handleStoreChange on notify.closeAll()', () => {
+    notify.success('A')
+    notify.success('B')
+    handleStoreChangeMockFn.mockClear()
+
+    notify.closeAll()
+
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([])
+  })
+
+  it('should apply configure() options to subsequently created toasts', () => {
+    notify.configure({ timeOut: 1000 })
+
+    notify.success('Configured')
+
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([
+      expect.objectContaining({ timeOut: 1000 }),
+    ])
+
+    notify.configure({ timeOut: defaultOptions.timeOut })
+  })
 })

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -94,9 +94,14 @@ describe('notify', () => {
     expect(handleStoreChangeMockFn).toHaveBeenCalledWith([])
   })
 
-  it('should NOT remove toast notify.dismiss() was called without toast ID', () => {
-    notify.dismiss()
+  it('should NOT remove toast if ID does not match any toast', () => {
+    notify.success('Success')
+    handleStoreChangeMockFn.mockClear()
 
-    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([])
+    notify.dismiss('no-such-id')
+
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'aaa-bbb' }),
+    ])
   })
 })

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,3 +1,5 @@
+import { type ReactNode } from 'react'
+
 import { MSG_TYPE, defaultOptions, type MsgType } from './utils/constants'
 import { generateUID } from './utils/helpers'
 
@@ -15,7 +17,7 @@ export interface ToastOptions {
 export interface ToastItem extends Required<ToastOptions> {
   id: string
   type: MsgType
-  content: string
+  content: ReactNode
 }
 
 export interface NotifyConfig {
@@ -45,7 +47,7 @@ class Notify {
 
   private createToast(
     type: MsgType,
-    content: string,
+    content: ReactNode,
     options: ToastOptions = {}
   ): ToastItem {
     const {
@@ -77,28 +79,27 @@ class Notify {
     this.onStoreChange(this.toasts)
   }
 
-  success = (content: string, options: ToastOptions = {}) => {
+  success = (content: ReactNode, options: ToastOptions = {}) => {
     const toast = this.createToast(MSG_TYPE.SUCCESS, content, options)
     this.addToast(toast)
   }
 
-  info = (content: string, options: ToastOptions = {}) => {
+  info = (content: ReactNode, options: ToastOptions = {}) => {
     const toast = this.createToast(MSG_TYPE.INFO, content, options)
     this.addToast(toast)
   }
 
-  warning = (content: string, options: ToastOptions = {}) => {
+  warning = (content: ReactNode, options: ToastOptions = {}) => {
     const toast = this.createToast(MSG_TYPE.WARNING, content, options)
     this.addToast(toast)
   }
 
-  error = (content: string, options: ToastOptions = {}) => {
+  error = (content: ReactNode, options: ToastOptions = {}) => {
     const toast = this.createToast(MSG_TYPE.ERROR, content, options)
     this.addToast(toast)
   }
 
-  dismiss = (id?: string) => {
-    if (!id) return
+  dismiss = (id: string) => {
     this.toasts = this.toasts.filter((item) => item.id !== id)
     this.onStoreChange(this.toasts)
   }

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -1,7 +1,5 @@
 const breakpoints = {
-  small: 320,
   medium: 600,
-  large: 1136,
 }
 
 export default breakpoints

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -48,5 +48,37 @@ describe('helpers', () => {
 
       spy.mockClear()
     })
+
+    it('should resume with remaining time after pause', () => {
+      const callbackMockFn = vi.fn()
+      const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+      const timer = new Timer(callbackMockFn, 3000)
+
+      vi.advanceTimersByTime(1000)
+      timer.pause()
+      timer.resume()
+
+      const lastCall = setTimeoutSpy.mock.calls.at(-1)!
+      expect(lastCall[1]).toBeLessThanOrEqual(2000)
+      expect(lastCall[1]).toBeGreaterThan(0)
+
+      setTimeoutSpy.mockClear()
+    })
+
+    it('should not produce negative remainingTime if pause() is called twice', () => {
+      const callbackMockFn = vi.fn()
+      const timer = new Timer(callbackMockFn, 100)
+
+      vi.advanceTimersByTime(60)
+      timer.pause()
+      vi.advanceTimersByTime(60)
+      timer.pause()
+      timer.resume()
+
+      vi.runOnlyPendingTimers()
+
+      // callback should fire (remainingTime clamped to 0, not negative)
+      expect(callbackMockFn).toHaveBeenCalled()
+    })
   })
 })

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 export function generateUID(): string {
-  const first = (Math.random() * 46656).toString(36).slice(-3)
+  const first = (Math.random() * 46656).toString(36).slice(-3) // 46656 = 36^3
   const second = Date.now().toString(36)
 
   return `${first}-${second}`

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -30,7 +30,10 @@ export class Timer {
 
   pause = (): void => {
     clearTimeout(this.timerId)
-    this.remainingTime -= Date.now() - this.startTime
+    this.remainingTime = Math.max(
+      0,
+      this.remainingTime - (Date.now() - this.startTime)
+    )
   }
 
   resume = (): void => {


### PR DESCRIPTION
## Summary

- **Remove BEM class names** (`ReactNoti__Toast--success`, etc.) — dead code that carried `// TODO: Remove` comments since inception
- **Add CSS custom properties** (`--react-noti-*`) as the primary theming mechanism — 14 variables for colours, radius, shadow, font, z-index; framework-agnostic, no Emotion knowledge needed
- **Add `classNames` prop** — per-slot CSS class injection (`toast`, `body`, `title`, `content`, `dismiss`, `progress`) for consumers who want to bring their own CSS
- **Performance**: `React.memo(Toast)` + `useCallback` on `handleStoreChange` to prevent unnecessary re-renders
- **Bug fixes**: `notify.configure()` moved out of render body into `useEffect`; `Timer.pause()` guarded against negative `remainingTime`; `content` type widened to `ReactNode`
- **a11y**: `aria-live="polite"` on container; `aria-label="Dismiss notification"` on dismiss button; `aria-hidden` on decorative icons
- **Build hygiene**: `exports` + `sideEffects` fields in `package.json`; Husky v9 hooks wired correctly; IE 11 dead code removed; `react-dom` removed from peer deps
- **CI**: automated GitHub Pages demo deploy after release; `CONTRIBUTING.md` added

## Breaking change

All `ReactNoti__*` BEM CSS class names are removed. Consumers who targeted them for styling must migrate to CSS custom properties or the new `classNames` prop.

## Test plan

- [x] `npm test` — 31/31 pass, 98.88% statement coverage
- [x] `npm run build` — ESM + CJS + types emit cleanly
- [x] `npm start` — visual smoke test: toasts render correctly, `--react-noti-*` variables visible in DevTools computed styles, no `ReactNoti__*` classes in DOM
- [ ] Verify `classNames` prop applies custom classes to correct slots
- [x] Verify CSS variable overrides (e.g. `--react-noti-bg-success`) change toast colours