### PR TITLE
fix(toast): render close icon as inline SVG so it displays

### DIFF
--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -2,7 +2,6 @@ import styled from '@emotion/styled'
 import { keyframes } from '@emotion/react'
 
 import colors from '../../styles/colors'
-import closeIconSrc from '../../assets/close-16.svg'
 import type { MsgType } from '../../utils/constants'
 
 const rnShrinkWidth = keyframes`
@@ -94,9 +93,12 @@ export const StyledBtnDismiss = styled.button`
   > span {
     width: 9px;
     height: 9px;
-    background-image: url(${closeIconSrc});
-    background-repeat: no-repeat;
-    background-position: center;
+  }
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
   }
 `
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -14,6 +14,7 @@ import SuccessIcon from '../../assets/checked.svg?react'
 import InfoIcon from '../../assets/info.svg?react'
 import WarningIcon from '../../assets/warning.svg?react'
 import ErrorIcon from '../../assets/cancel.svg?react'
+import CloseIcon from '../../assets/close-16.svg?react'
 
 import {
   StyledToast,
@@ -132,7 +133,9 @@ function Toast({
         onClick={handleDismiss}
         data-testid="react-noti-dismiss"
       >
-        <StyledIcon aria-hidden="true" />
+        <StyledIcon aria-hidden="true">
+          <CloseIcon />
+        </StyledIcon>
       </StyledBtnDismiss>
 
       {autoDismiss && showProgress === true && (


### PR DESCRIPTION
## Problem

The toast close (dismiss) icon stopped displaying. Since the Rollup→Vite migration, Vite inlines `close-16.svg` as a **URL-encoded** data URI containing literal single quotes (`xmlns='...'`), and Emotion interpolated it into an **unquoted** `url()`:

```css
background-image: url(data:image/svg+xml,...xmlns='http://...'...)
```

Per the CSS spec an unquoted `url()` token may not contain unescaped `'`, so browsers discard the entire declaration and no icon renders. Wrapping the interpolation in quotes doesn't survive the toolchain — Prettier rewrites `"…"` to `'…'` inside the Emotion CSS, which then collides with the data URI's own single quotes.

## Fix

Render the close icon as an **inline SVG component** (`close-16.svg?react`) inside `StyledIcon`, matching the pattern already used by the four type icons, instead of a `background-image` data URI. This removes the quoting problem entirely and lets the icon inherit `currentColor`.

## Verification

- lint / prettier / typecheck ✅
- 31/31 tests ✅
- library build ✅ — `background-image` now 0 occurrences; close SVG inlined as a component
- `npm start` dev server compiles and serves cleanly