### PR TITLE
fix(toast): correctness fixes — per-toast showProgress & unique ids

### DIFF
--- a/src/components/ReactNoti/ReactNoti.test.tsx
+++ b/src/components/ReactNoti/ReactNoti.test.tsx
@@ -45,4 +45,15 @@ describe('<ReactNoti />', () => {
       MSG_TYPE.INFO
     )
   })
+
+  it('should honor the per-toast showProgress option over the container prop', () => {
+    const { queryByTestId } = render(<ReactNoti showProgress />)
+
+    act(() => {
+      notify.closeAll()
+      notify.success(MSG_TYPE.SUCCESS, { showProgress: false })
+    })
+
+    expect(queryByTestId('react-noti-progress')).toBeNull()
+  })
 })

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -74,7 +74,7 @@ export function ReactNoti({
               timeOut={t.timeOut}
               icons={icons}
               pauseOnHover={t.pauseOnHover}
-              showProgress={showProgress}
+              showProgress={t.showProgress}
               onDismiss={notify.dismiss}
               classNames={classNames}
             />

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -8,6 +8,17 @@ describe('helpers', () => {
 
       expect(firstID).not.toEqual(secondID)
     })
+
+    it('should generate unique IDs when called rapidly within the same millisecond', () => {
+      const now = 1_700_000_000_000
+      const dateSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+
+      const ids = Array.from({ length: 1000 }, () => generateUID())
+
+      expect(new Set(ids).size).toBe(ids.length)
+
+      dateSpy.mockRestore()
+    })
   })
 
   describe('Timer', () => {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,8 +1,14 @@
-export function generateUID(): string {
-  const first = (Math.random() * 46656).toString(36).slice(-3) // 46656 = 36^3
-  const second = Date.now().toString(36)
+// Monotonic counter so IDs generated within the same millisecond can never collide.
+let seq = 0
 
-  return `${first}-${second}`
+export function generateUID(): string {
+  const time = Date.now().toString(36)
+  const count = (seq++).toString(36) // strictly increasing, guarantees per-session uniqueness
+  const rand = Math.floor(Math.random() * 46656) // 46656 = 36^3
+    .toString(36)
+    .padStart(3, '0')
+
+  return `${time}-${count}-${rand}`
 }
 
 type TimerCallback = () => void


### PR DESCRIPTION
## Summary

First feature (**F1**) of the one-year improvement roadmap. Two focused correctness fixes:

- **Honor per-toast `showProgress`.** `ReactNoti` passed the container-level `showProgress` prop to every `Toast`, so a per-toast option (e.g. `notify.success(msg, { showProgress: false })`) was silently ignored. Now passes `t.showProgress`.
- **Guarantee unique toast ids.** `generateUID()` used `Date.now()` + a 3-char random slice, which could collide when several toasts were created within the same millisecond → duplicate React keys. Added a monotonic per-session counter segment so ids are always unique.

## Tests

- `ReactNoti.test.tsx`: per-toast `showProgress: false` renders no progress bar even when the container sets `showProgress`.
- `helpers.test.ts`: 1000 rapid `generateUID()` calls with `Date.now()` pinned all produce unique ids.

All 33 tests pass; lint, typecheck, build, and `validate:package` (publint + attw) green. No dependency or API changes; gzip size unchanged (~4 KB).