### PR TITLE
feat(notify): return the toast id from triggers & accept a custom id

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ export default App
 
 | Option        | Type      | Default     | Description |
 | ------------- | --------- | ----------- | ----------- |
+| `id`          | `string`  | auto        | Supply your own id to target this toast later. Defaults to an auto-generated unique id. |
 | `title`       | `string`  | `undefined` | Title displayed above the toast body. |
 | `autoDismiss` | `boolean` | `true`      | Override the container `autoDismiss` for this toast. |
 | `timeOut`     | `number`  | `5000`      | Override the container `timeOut` for this toast. |
@@ -181,6 +182,11 @@ notify.success('Plain text toast')
 notify.info('With title and custom timeout', { title: 'Note', timeOut: 8000 })
 notify.warning(<Avatar src="/avatar.png" />, { autoDismiss: false })
 notify.error('Something failed', { title: 'Error', pauseOnHover: false })
+
+// Every trigger returns the toast id, so you can dismiss it programmatically
+const id = notify.info('Uploading…', { autoDismiss: false })
+// …later
+notify.dismiss(id)
 
 // Dismiss all toasts
 notify.closeAll()

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -86,6 +86,30 @@ describe('notify', () => {
     expect(handleStoreChangeMockFn).toHaveBeenCalledWith([newToast])
   })
 
+  it('should return the generated id from a trigger', () => {
+    const id = notify.success('Success')
+
+    expect(id).toBe('aaa-bbb')
+  })
+
+  it('should use a caller-supplied id and return it', () => {
+    const id = notify.success('Success', { id: 'my-id' })
+
+    expect(id).toBe('my-id')
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'my-id' }),
+    ])
+  })
+
+  it('should allow dismissing a toast by its returned id', () => {
+    const id = notify.info('Info', { id: 'info-1' })
+    handleStoreChangeMockFn.mockClear()
+
+    notify.dismiss(id)
+
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([])
+  })
+
   it('should remove toast and call handleStoreChange if notify.dismiss() was called with toast ID', () => {
     notify.success('Success')
 

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -7,6 +7,8 @@ import { generateUID } from './utils/helpers'
 export type ToastType = MsgType
 
 export interface ToastOptions {
+  /** Supply your own id to target this toast later (e.g. dismiss or update). */
+  id?: string
   title?: string
   autoDismiss?: boolean
   timeOut?: number
@@ -51,6 +53,7 @@ class Notify {
     options: ToastOptions = {}
   ): ToastItem {
     const {
+      id = generateUID(),
       title = '',
       autoDismiss = this.config.autoDismiss,
       timeOut = this.config.timeOut,
@@ -58,7 +61,7 @@ class Notify {
       showProgress = this.config.showProgress,
     } = options
     return {
-      id: generateUID(),
+      id,
       type,
       content,
       title,
@@ -79,24 +82,28 @@ class Notify {
     this.onStoreChange(this.toasts)
   }
 
-  success = (content: ReactNode, options: ToastOptions = {}) => {
+  success = (content: ReactNode, options: ToastOptions = {}): string => {
     const toast = this.createToast(MSG_TYPE.SUCCESS, content, options)
     this.addToast(toast)
+    return toast.id
   }
 
-  info = (content: ReactNode, options: ToastOptions = {}) => {
+  info = (content: ReactNode, options: ToastOptions = {}): string => {
     const toast = this.createToast(MSG_TYPE.INFO, content, options)
     this.addToast(toast)
+    return toast.id
   }
 
-  warning = (content: ReactNode, options: ToastOptions = {}) => {
+  warning = (content: ReactNode, options: ToastOptions = {}): string => {
     const toast = this.createToast(MSG_TYPE.WARNING, content, options)
     this.addToast(toast)
+    return toast.id
   }
 
-  error = (content: ReactNode, options: ToastOptions = {}) => {
+  error = (content: ReactNode, options: ToastOptions = {}): string => {
     const toast = this.createToast(MSG_TYPE.ERROR, content, options)
     this.addToast(toast)
+    return toast.id
   }
 
   dismiss = (id: string) => {


### PR DESCRIPTION
## Summary

Second feature (**F2**) of the roadmap, and the foundation for programmatic control of individual toasts.

- `notify.success/info/warning/error` now **return the generated toast id** (`string`), so callers can dismiss a specific toast: `const id = notify.info('Uploading…', { autoDismiss: false }); notify.dismiss(id)`.
- Callers may also **supply their own id** via `options.id`; it defaults to an auto-generated unique id. This is the groundwork for `notify.update` / upsert in a later PR.

## Changes
- `src/notify.ts`: `id?: string` added to `ToastOptions`; `createToast` honors a supplied id; the four triggers return `toast.id`.
- `README.md`: documented the return value and the `id` option (options table + usage example).

## Tests
Added to `src/notify.test.ts`: returns the generated id, uses & returns a caller-supplied id, and dismiss-by-returned-id removes the toast.

All 36 tests pass; lint, typecheck, build, and `validate:package` (publint + attw) green. No breaking changes — the return type widens from `void` to `string`. gzip ~4.1 KB.