### PR TITLE
feat(store): rewrite store on useSyncExternalStore

### DIFF
--- a/src/components/ReactNoti/ReactNoti.test.tsx
+++ b/src/components/ReactNoti/ReactNoti.test.tsx
@@ -1,10 +1,16 @@
-import { render, act } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 
 import ReactNoti from './ReactNoti'
 import notify from '../../notify'
 import { POSITION, MSG_TYPE } from '../../utils/constants'
 
 describe('<ReactNoti />', () => {
+  afterEach(() => {
+    act(() => {
+      notify.closeAll()
+    })
+  })
+
   it('renders without crashing', () => {
     render(<ReactNoti />)
   })
@@ -30,7 +36,7 @@ describe('<ReactNoti />', () => {
     expect(queryByText(MSG_TYPE.SUCCESS)).not.toBeTruthy()
   })
 
-  it('should render notification in reverse order if position is BOTTOM', () => {
+  it('should render the newest toast last when position is BOTTOM', () => {
     const { getAllByTestId } = render(
       <ReactNoti position={POSITION.BOTTOM_RIGHT} />
     )
@@ -40,8 +46,9 @@ describe('<ReactNoti />', () => {
       notify.success(MSG_TYPE.INFO)
     })
 
-    const [firstToast] = getAllByTestId('react-noti-toast')
-    expect(firstToast.querySelector('section')?.textContent).toEqual(
+    const toasts = getAllByTestId('react-noti-toast')
+    const lastToast = toasts[toasts.length - 1]
+    expect(lastToast.querySelector('section')?.textContent).toEqual(
       MSG_TYPE.INFO
     )
   })
@@ -50,10 +57,20 @@ describe('<ReactNoti />', () => {
     const { queryByTestId } = render(<ReactNoti showProgress />)
 
     act(() => {
-      notify.closeAll()
       notify.success(MSG_TYPE.SUCCESS, { showProgress: false })
     })
 
     expect(queryByTestId('react-noti-progress')).toBeNull()
+  })
+
+  it('should render the same toast in every mounted container', () => {
+    render(<ReactNoti />)
+    render(<ReactNoti />)
+
+    act(() => {
+      notify.success('shared')
+    })
+
+    expect(screen.getAllByText('shared')).toHaveLength(2)
   })
 })

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useMemo, useSyncExternalStore } from 'react'
 
 import Toast, { type NotiClassNames } from '../Toast'
-import notify, { type ToastItem } from '../../notify'
+import notify from '../../notify'
 import { defaultOptions, type Position } from '../../utils/constants'
 import { StyledReactNoti, StyledTray } from './ReactNoti.styled'
 
@@ -28,18 +28,17 @@ export function ReactNoti({
   className,
   classNames,
 }: ReactNotiProps) {
-  const [toasts, setToasts] = useState<ToastItem[]>([])
-
-  const handleStoreChange = useCallback(
-    (newToasts: ToastItem[]) => {
-      const [pos] = position.split('-')
-      const nextToasts =
-        pos === 'bottom' ? [...newToasts].reverse() : [...newToasts]
-
-      setToasts(nextToasts)
-    },
-    [position]
+  const toasts = useSyncExternalStore(
+    notify.subscribe,
+    notify.getSnapshot,
+    notify.getServerSnapshot
   )
+
+  // Bottom positions render newest-last so it sits closest to the screen edge.
+  const orderedToasts = useMemo(() => {
+    const [pos] = position.split('-')
+    return pos === 'bottom' ? [...toasts].reverse() : toasts
+  }, [toasts, position])
 
   useEffect(() => {
     notify.configure({
@@ -51,19 +50,15 @@ export function ReactNoti({
     })
   }, [autoDismiss, timeOut, single, pauseOnHover, showProgress])
 
-  useEffect(() => {
-    notify.register({ handleStoreChange })
-  }, [handleStoreChange])
-
   return (
     <StyledReactNoti
       className={className}
       aria-live="polite"
       aria-atomic="false"
     >
-      {toasts.length > 0 && (
+      {orderedToasts.length > 0 && (
         <StyledTray position={position}>
-          {toasts.map((t) => (
+          {orderedToasts.map((t) => (
             <Toast
               key={t.id}
               id={t.id}

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -34,6 +34,9 @@ export interface RegisterOptions {
   handleStoreChange: (toasts: ToastItem[]) => void
 }
 
+// Stable reference for the server snapshot (useSyncExternalStore requires it).
+const EMPTY_TOASTS: ToastItem[] = []
+
 class Notify {
   private toasts: ToastItem[] = []
 
@@ -45,7 +48,14 @@ class Notify {
     showProgress: defaultOptions.showProgress,
   }
 
-  private onStoreChange: (toasts: ToastItem[]) => void = () => {}
+  private listeners = new Set<() => void>()
+
+  // A single legacy subscription backing the deprecated register() API.
+  private legacyUnsubscribe: (() => void) | null = null
+
+  private emit() {
+    this.listeners.forEach((listener) => listener())
+  }
 
   private createToast(
     type: MsgType,
@@ -73,13 +83,8 @@ class Notify {
   }
 
   private addToast(toast: ToastItem) {
-    if (this.config.single) {
-      this.toasts.length = 0
-      this.toasts.push(toast)
-    } else {
-      this.toasts.unshift(toast)
-    }
-    this.onStoreChange(this.toasts)
+    this.toasts = this.config.single ? [toast] : [toast, ...this.toasts]
+    this.emit()
   }
 
   success = (content: ReactNode, options: ToastOptions = {}): string => {
@@ -108,12 +113,12 @@ class Notify {
 
   dismiss = (id: string) => {
     this.toasts = this.toasts.filter((item) => item.id !== id)
-    this.onStoreChange(this.toasts)
+    this.emit()
   }
 
   closeAll = () => {
-    this.toasts.length = 0
-    this.onStoreChange(this.toasts)
+    this.toasts = []
+    this.emit()
   }
 
   configure({
@@ -133,8 +138,33 @@ class Notify {
     }
   }
 
-  register({ handleStoreChange }: RegisterOptions) {
-    this.onStoreChange = handleStoreChange
+  /**
+   * Subscribe to store changes. Returns an unsubscribe function.
+   * Designed for React's `useSyncExternalStore`, but usable standalone.
+   */
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  /** Current toast list. Reference changes only when the store changes. */
+  getSnapshot = (): ToastItem[] => this.toasts
+
+  /** Server render always starts empty — toasts are ephemeral client state. */
+  getServerSnapshot = (): ToastItem[] => EMPTY_TOASTS
+
+  /**
+   * @deprecated Use `subscribe` + `getSnapshot` (via `useSyncExternalStore`)
+   * instead. Kept for backward compatibility; supports a single listener.
+   */
+  register = ({ handleStoreChange }: RegisterOptions) => {
+    if (this.legacyUnsubscribe) this.legacyUnsubscribe()
+    this.legacyUnsubscribe = this.subscribe(() =>
+      handleStoreChange(this.getSnapshot())
+    )
+    handleStoreChange(this.getSnapshot())
   }
 }
 


### PR DESCRIPTION
## Summary

Third feature (**F3**) of the roadmap — the structural rewrite that unblocks the rest. Replaces the single-callback observer in `notify` with a proper listener set and consumes it from `ReactNoti` via React's `useSyncExternalStore`.

## Why

The old store held one `onStoreChange` callback that each `ReactNoti` overwrote on mount, and it mutated a shared `toasts` array in place. That meant:

- Only one container could ever be mounted (a second clobbered the first).
- Unmounting never unregistered → stale-listener risk.
- `setState` received the same array reference, relying on the consumer to copy it — fragile and not concurrent-render safe.

## Changes

- `src/notify.ts`: `subscribe(listener) → unsubscribe`, `getSnapshot()`, `getServerSnapshot()`; a `Set` of listeners with `emit()`; all mutations (`addToast`/`dismiss`/`closeAll`) now produce a new immutable array. `register()` is retained as a **deprecated** backward-compatible shim (no breaking change).
- `src/components/ReactNoti/ReactNoti.tsx`: consumes the store via `useSyncExternalStore`; bottom-position ordering derived with `useMemo`. Subscribes on mount / unsubscribes on unmount.
- `ReactNoti.test.tsx`: added `closeAll` isolation between tests, a **multi-container** test, and corrected the bottom-position test (it had been passing on leaked singleton state).

## Verification

37 tests pass; lint, typecheck, library build, demo build, and `validate:package` (publint + attw) all green. `getServerSnapshot` adds SSR resilience ahead of the dedicated SSR work. gzip ~4.1 KB.