### PR TITLE
ci: serialize GitHub Pages deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
     if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master' && github.repository == 'vitaliiburlaka/react-noti' }}
     runs-on: ubuntu-latest
 
+    # Serialize Pages deployments so back-to-back releases don't collide
+    # ("in progress deployment" 400). Queue rather than cancel so every
+    # release still publishes its demo.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Problem

The demo deploy for the `4.1.0` release failed:

> Error: Creating Pages deployment failed … Deployment request failed … due to in progress deployment. Please cancel `<prev>` first or wait for it to complete.

Shipping one feature per PR means releases land close together, and each release's `deploy` job started a GitHub Pages deployment while the previous one was still in progress — `actions/deploy-pages` rejects that with a 400.

## Fix

Add a `concurrency` group scoped to the `deploy` job:

```yaml
concurrency:
  group: pages
  cancel-in-progress: false
```

`cancel-in-progress: false` queues deployments instead of cancelling, so every release still publishes its demo — they just run one at a time. This is GitHub's recommended pattern for Pages and is scoped to `deploy` only, so it doesn't serialize `test`/`release`.

Pure CI change — no package changes, so it triggers no release. **Worth merging before the next feature release** so that release's deploy picks up the fix.