### PR TITLE
feat(notify): add update() and in-place upsert by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ const id = notify.info('Uploading…', { autoDismiss: false })
 // …later
 notify.dismiss(id)
 
+// Update a toast in place (keeps its type and position). Returns `false`
+// if no toast with that id exists.
+notify.update(id, 'Upload complete', { autoDismiss: true, timeOut: 4000 })
+
+// Re-using an id replaces that toast in place — handy for progress that
+// changes type, e.g. loading → success
+notify.info('Saving…', { id: 'save', autoDismiss: false })
+notify.success('Saved', { id: 'save' })
+
 // Dismiss all toasts
 notify.closeAll()
 ```

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -110,6 +110,48 @@ describe('notify', () => {
     expect(handleStoreChangeMockFn).toHaveBeenCalledWith([])
   })
 
+  it('should update an existing toast in place and return true', () => {
+    notify.success('Original', { id: 'up-1' })
+    handleStoreChangeMockFn.mockClear()
+
+    const result = notify.update('up-1', 'Updated', { title: 'New' })
+
+    expect(result).toBe(true)
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'up-1',
+        type: MSG_TYPE.SUCCESS,
+        content: 'Updated',
+        title: 'New',
+      }),
+    ])
+  })
+
+  it('should return false and not emit when updating a non-existent toast', () => {
+    notify.success('Original', { id: 'up-2' })
+    handleStoreChangeMockFn.mockClear()
+
+    const result = notify.update('missing', 'Nope')
+
+    expect(result).toBe(false)
+    expect(handleStoreChangeMockFn).not.toHaveBeenCalled()
+  })
+
+  it('should replace a toast in place when an id is reused', () => {
+    notify.info('First', { id: 'dup' })
+    notify.success('Second', { id: 'dup' })
+
+    const lastCall = handleStoreChangeMockFn.mock.calls.at(-1)![0]
+    expect(lastCall).toHaveLength(1)
+    expect(lastCall[0]).toEqual(
+      expect.objectContaining({
+        id: 'dup',
+        type: MSG_TYPE.SUCCESS,
+        content: 'Second',
+      })
+    )
+  })
+
   it('should remove toast and call handleStoreChange if notify.dismiss() was called with toast ID', () => {
     notify.success('Success')
 

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -83,7 +83,16 @@ class Notify {
   }
 
   private addToast(toast: ToastItem) {
-    this.toasts = this.config.single ? [toast] : [toast, ...this.toasts]
+    if (this.config.single) {
+      this.toasts = [toast]
+    } else {
+      const index = this.toasts.findIndex((t) => t.id === toast.id)
+      this.toasts =
+        index === -1
+          ? [toast, ...this.toasts]
+          : // Re-using an existing id replaces that toast in place.
+            this.toasts.map((t, i) => (i === index ? toast : t))
+    }
     this.emit()
   }
 
@@ -109,6 +118,33 @@ class Notify {
     const toast = this.createToast(MSG_TYPE.ERROR, content, options)
     this.addToast(toast)
     return toast.id
+  }
+
+  /**
+   * Update an existing toast in place, preserving its type and position.
+   * Returns `true` if a toast with the given id was found, otherwise `false`.
+   */
+  update = (
+    id: string,
+    content: ReactNode,
+    options: Omit<ToastOptions, 'id'> = {}
+  ): boolean => {
+    const index = this.toasts.findIndex((t) => t.id === id)
+    if (index === -1) return false
+
+    const prev = this.toasts[index]
+    const next: ToastItem = {
+      ...prev,
+      content,
+      title: options.title ?? prev.title,
+      autoDismiss: options.autoDismiss ?? prev.autoDismiss,
+      timeOut: options.timeOut ?? prev.timeOut,
+      pauseOnHover: options.pauseOnHover ?? prev.pauseOnHover,
+      showProgress: options.showProgress ?? prev.showProgress,
+    }
+    this.toasts = this.toasts.map((t, i) => (i === index ? next : t))
+    this.emit()
+    return true
   }
 
   dismiss = (id: string) => {


### PR DESCRIPTION
## Summary

Fourth feature (**F4**) of the roadmap. Builds directly on the id-addressable, immutable store from F2/F3 to give programmatic control over an individual toast.

- **`notify.update(id, content, options?)`** — updates a toast in place, preserving its **type** and **position** in the stack. Returns `true` if a toast with that id existed, `false` otherwise. Emits nothing on a miss.
- **Upsert on id reuse** — calling any trigger with an id that already exists now **replaces that toast in place** (same position) instead of creating a duplicate. This also enables changing a toast's type, e.g. `loading → success` on a single toast, which the upcoming promise API (F5) will use.

```ts
const id = notify.info('Uploading…', { autoDismiss: false })
notify.update(id, 'Upload complete', { autoDismiss: true, timeOut: 4000 })

// or, via id reuse (can change type):
notify.info('Saving…', { id: 'save', autoDismiss: false })
notify.success('Saved', { id: 'save' })
```

## Notes / limitations
- `update` re-uses the same React key (the id), so content/title/showProgress update live. Changing `timeOut` does **not** restart an already-running auto-dismiss timer — a Toast-level enhancement I'd fold into the animation work (F6).

## Verification
40 tests pass (+3: update-in-place, update-miss returns false, id-reuse replaces in place). Lint, typecheck, build, demo build, and `validate:package` (publint + attw) green. gzip ~4.2 KB.

Also confirms the F3 release deployed cleanly — the Pages concurrency guard from #23 worked.