### PR TITLE
ci: retry GitHub Pages deploy on transient backend failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
     environment:
       name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      url: ${{ steps.deploy.outputs.page_url || steps.deploy-retry.outputs.page_url }}
 
     steps:
       - name: Checkout repo
@@ -135,6 +135,19 @@ jobs:
         with:
           path: examples/build
 
+      # The Pages backend intermittently returns "Deployment failed, try
+      # again later." even when the artifact is fine. Allow one retry after a
+      # short pause before failing the job.
       - name: Deploy to GitHub Pages
         id: deploy
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+
+      - name: Wait before retrying deploy
+        if: steps.deploy.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (retry)
+        id: deploy-retry
+        if: steps.deploy.outcome == 'failure'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The `4.3.0` release (F4 merge) published to npm fine, but its **demo deploy failed**:

> ##[error]Deployment failed, try again later.

The demo build and artifact upload both succeeded — the GitHub Pages **backend** intermittently rejects the deployment hand-off with this generic, retryable error. (A subsequent `rerun --failed` then hit a *different*, self-inflicted error — "Multiple artifacts named github-pages… count is 2" — because rerunning the job re-ran the upload step. That is avoided below.)

## Fix

Retry the `deploy-pages` step **once** after a short pause:

```yaml
- name: Deploy to GitHub Pages
  id: deploy
  uses: actions/deploy-pages@v4
  continue-on-error: true
- name: Wait before retrying deploy
  if: steps.deploy.outcome == 'failure'
  run: sleep 30
- name: Deploy to GitHub Pages (retry)
  id: deploy-retry
  if: steps.deploy.outcome == 'failure'
  uses: actions/deploy-pages@v4
```

Key point: only the **deploy** step is retried, **not** the artifact upload, so a retry can never create a duplicate `github-pages` artifact. The environment URL now resolves from whichever attempt succeeds.

Pure CI change — triggers no release. Complements the `concurrency: pages` guard from #23 (that prevents *concurrent* deploys; this handles a *transient backend* failure).

## After merge
The failed `4.3.0` run can't be salvaged by rerun (duplicate artifacts), so a fresh `workflow_dispatch` run on `master` will be triggered to publish the current demo cleanly.