### PR TITLE
feat(notify): add promise toasts and a loading type

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ notify.update(id, 'Upload complete', { autoDismiss: true, timeOut: 4000 })
 notify.info('Saving…', { id: 'save', autoDismiss: false })
 notify.success('Saved', { id: 'save' })
 
+// A pending "loading" toast with an animated spinner (no auto-dismiss)
+notify.loading('Working on it…')
+
+// Or drive it from a promise: shows loading, then swaps to success/error
+// in place. Success/error messages may be functions of the resolved value.
+notify.promise(saveUser(), {
+  loading: 'Saving…',
+  success: (user) => `Saved ${user.name}`,
+  error: (err) => `Save failed: ${err.message}`,
+})
+
 // Dismiss all toasts
 notify.closeAll()
 ```

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -56,6 +56,25 @@ function App() {
     }
   }
 
+  const handlePromiseClick = () => {
+    const request = new Promise<string>((resolve, reject) => {
+      setTimeout(() => {
+        if (Math.random() > 0.3) resolve('data')
+        else reject(new Error('Request failed'))
+      }, 2000)
+    })
+
+    notify.promise(
+      request,
+      {
+        loading: 'Processing your request…',
+        success: 'All done!',
+        error: (err) => (err as Error).message,
+      },
+      { title: 'Promise' }
+    )
+  }
+
   return (
     <StyledApp className="App">
       <ReactNoti
@@ -77,6 +96,7 @@ function App() {
           timeOut={timeOut}
           handleTimeOutChange={handleTimeOutChange}
           handleOnClick={handleOnClick}
+          handlePromiseClick={handlePromiseClick}
           autoDismiss={autoDismiss}
           handleAutoDismissChange={handleAutoDismissChange}
           icons={icons}

--- a/examples/src/components/DemoPanel/DemoPanel.tsx
+++ b/examples/src/components/DemoPanel/DemoPanel.tsx
@@ -18,6 +18,7 @@ interface DemoPanelProps {
   timeOut: number
   handleTimeOutChange: (event: ChangeEvent<HTMLInputElement>) => void
   handleOnClick: (type: MsgType) => void
+  handlePromiseClick: () => void
   autoDismiss: boolean
   handleAutoDismissChange: () => void
   icons: boolean
@@ -36,6 +37,7 @@ function DemoPanel({
   timeOut,
   handleTimeOutChange,
   handleOnClick,
+  handlePromiseClick,
   autoDismiss,
   handleAutoDismissChange,
   icons,
@@ -69,6 +71,13 @@ function DemoPanel({
               {MSG_TYPE[k]}
             </StyledButton>
           ))}
+          <StyledButton
+            type="button"
+            kind={MSG_TYPE.INFO}
+            onClick={handlePromiseClick}
+          >
+            promise
+          </StyledButton>
         </StyledDemoButtons>
 
         <StyledDemoProps>

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -13,6 +13,23 @@ const rnShrinkWidth = keyframes`
   }
 `
 
+const rnSpin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+// Loading spinner (rendered in place of a type icon for the `loading` type)
+export const StyledSpinner = styled.span`
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ${rnSpin} 0.7s linear infinite;
+`
+
 // Root
 export const StyledToast = styled('div', {
   shouldForwardProp: (prop) => prop !== 'type',

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -141,6 +141,35 @@ describe('<Toast />', () => {
     expect(onDismissMockFn).toHaveBeenCalledWith(props.id)
   })
 
+  it('should render a spinner for the loading type', () => {
+    const props = { ...defaultProps, type: MSG_TYPE.LOADING }
+
+    const { getByTestId } = render(<Toast {...props} />)
+
+    expect(getByTestId('react-noti-spinner')).toBeInTheDocument()
+  })
+
+  it('should (re)start the auto-dismiss timer when autoDismiss turns on', () => {
+    const onDismissMockFn = vi.fn()
+    const props = {
+      ...defaultProps,
+      type: MSG_TYPE.LOADING,
+      autoDismiss: false,
+      onDismiss: onDismissMockFn,
+    }
+
+    const { rerender } = render(<Toast {...props} />)
+    vi.runOnlyPendingTimers()
+    expect(onDismissMockFn).not.toHaveBeenCalled()
+
+    rerender(
+      <Toast {...props} type={MSG_TYPE.SUCCESS} autoDismiss timeOut={5000} />
+    )
+    vi.runOnlyPendingTimers()
+
+    expect(onDismissMockFn).toHaveBeenCalledWith(props.id)
+  })
+
   it('should apply classNames to toast slots', () => {
     const props = {
       ...defaultProps,

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -23,6 +23,7 @@ import {
   StyledIcon,
   StyledBtnDismiss,
   StyledProgress,
+  StyledSpinner,
 } from './Toast.styled'
 
 const iconsMap: Record<MsgType, ReactElement> = {
@@ -30,6 +31,7 @@ const iconsMap: Record<MsgType, ReactElement> = {
   info: <InfoIcon />,
   warning: <WarningIcon />,
   error: <ErrorIcon />,
+  loading: <StyledSpinner data-testid="react-noti-spinner" />,
 }
 
 export interface NotiClassNames {
@@ -69,31 +71,28 @@ function Toast({
   classNames = {},
 }: ToastProps) {
   const timer = useRef<Timer | null>(null)
-  const [isRunning, setIsRunning] = useState(autoDismiss)
+  const [isRunning, setIsRunning] = useState(false)
 
   const handleDismiss = () => {
     onDismiss(id)
   }
 
-  const startTimer = () => {
-    if (!autoDismiss || timeOut <= 0) return
-
-    timer.current = new Timer(handleDismiss, timeOut)
-    setIsRunning(true)
-  }
-
-  const clearTimer = () => {
-    if (timer.current) timer.current.clear()
-  }
-
+  // (Re)start the auto-dismiss timer whenever the timing props change — this
+  // is what lets an in-place update (e.g. loading -> success) begin dismissing.
   useEffect(() => {
-    startTimer()
+    if (!autoDismiss || timeOut <= 0) {
+      setIsRunning(false)
+      return undefined
+    }
+
+    timer.current = new Timer(() => onDismiss(id), timeOut)
+    setIsRunning(true)
 
     return () => {
-      clearTimer()
+      timer.current?.clear()
+      timer.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [autoDismiss, timeOut, id, onDismiss])
 
   const onMouseEnter = () => {
     if (!pauseOnHover || !timer.current) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
   ToastOptions,
   NotifyConfig,
   RegisterOptions,
+  PromiseMessages,
 } from './notify'
 export type { NotiClassNames } from './components/Toast'
 export type { ReactNotiProps } from './components/ReactNoti'

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -110,6 +110,63 @@ describe('notify', () => {
     expect(handleStoreChangeMockFn).toHaveBeenCalledWith([])
   })
 
+  it('should create a non-dismissing loading toast', () => {
+    notify.loading('Loading', { id: 'load-1' })
+
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'load-1',
+        type: MSG_TYPE.LOADING,
+        autoDismiss: false,
+        showProgress: false,
+      }),
+    ])
+  })
+
+  it('should turn a promise into a loading toast that resolves to success', async () => {
+    const promise = Promise.resolve('done')
+
+    notify.promise(promise, {
+      loading: 'Loading',
+      success: 'Success',
+      error: 'Error',
+    })
+
+    expect(handleStoreChangeMockFn).toHaveBeenLastCalledWith([
+      expect.objectContaining({ type: MSG_TYPE.LOADING, content: 'Loading' }),
+    ])
+
+    await promise
+    await Promise.resolve()
+
+    const toasts = handleStoreChangeMockFn.mock.calls.at(-1)![0]
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0]).toEqual(
+      expect.objectContaining({ type: MSG_TYPE.SUCCESS, content: 'Success' })
+    )
+  })
+
+  it('should update the promise toast to error on rejection', async () => {
+    const promise = Promise.reject(new Error('boom'))
+
+    await notify
+      .promise(promise, {
+        loading: 'Loading',
+        success: 'Success',
+        error: (err) => `Failed: ${(err as Error).message}`,
+      })
+      .catch(() => {})
+    await Promise.resolve()
+
+    const toasts = handleStoreChangeMockFn.mock.calls.at(-1)![0]
+    expect(toasts[0]).toEqual(
+      expect.objectContaining({
+        type: MSG_TYPE.ERROR,
+        content: 'Failed: boom',
+      })
+    )
+  })
+
   it('should update an existing toast in place and return true', () => {
     notify.success('Original', { id: 'up-1' })
     handleStoreChangeMockFn.mockClear()

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -34,6 +34,19 @@ export interface RegisterOptions {
   handleStoreChange: (toasts: ToastItem[]) => void
 }
 
+/** A message that is either static content or derived from the resolved value. */
+type PromiseMessage<T> = ReactNode | ((value: T) => ReactNode)
+
+export interface PromiseMessages<T> {
+  loading: ReactNode
+  success: PromiseMessage<T>
+  error: PromiseMessage<unknown>
+}
+
+function resolveMessage<T>(message: PromiseMessage<T>, value: T): ReactNode {
+  return typeof message === 'function' ? message(value) : message
+}
+
 // Stable reference for the server snapshot (useSyncExternalStore requires it).
 const EMPTY_TOASTS: ToastItem[] = []
 
@@ -118,6 +131,43 @@ class Notify {
     const toast = this.createToast(MSG_TYPE.ERROR, content, options)
     this.addToast(toast)
     return toast.id
+  }
+
+  loading = (content: ReactNode, options: ToastOptions = {}): string => {
+    // Loading toasts are pending by default: no auto-dismiss, no progress bar.
+    const toast = this.createToast(MSG_TYPE.LOADING, content, {
+      autoDismiss: false,
+      showProgress: false,
+      ...options,
+    })
+    this.addToast(toast)
+    return toast.id
+  }
+
+  /**
+   * Show a loading toast that resolves to a success or error toast in place.
+   * Returns the original promise so callers can still await/chain it.
+   */
+  promise = <T>(
+    promise: Promise<T>,
+    messages: PromiseMessages<T>,
+    options: Omit<ToastOptions, 'id'> = {}
+  ): Promise<T> => {
+    const id = this.loading(messages.loading, options)
+
+    promise.then(
+      (value) => {
+        this.success(resolveMessage(messages.success, value), {
+          ...options,
+          id,
+        })
+      },
+      (error: unknown) => {
+        this.error(resolveMessage(messages.error, error), { ...options, id })
+      }
+    )
+
+    return promise
   }
 
   /**

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -4,10 +4,12 @@ const colors = {
   info: '#d9eaf1',
   warning: '#fff0de',
   error: '#ffe7e2',
+  loading: '#eceef0',
   successDark: '#8adfad',
   infoDark: '#8ec1d6',
   warningDark: '#ffc278',
   errorDark: '#ff937c',
+  loadingDark: '#b9c0c7',
 }
 
 export default colors

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,6 +3,7 @@ export const MSG_TYPE = {
   INFO: 'info',
   WARNING: 'warning',
   ERROR: 'error',
+  LOADING: 'loading',
 } as const
 
 export type MsgType = (typeof MSG_TYPE)[keyof typeof MSG_TYPE]


### PR DESCRIPTION
## Summary

Fifth feature (**F5**) of the roadmap — brings react-noti to parity with react-hot-toast / sonner on the most-requested feature.

- **`loading` message type** — an animated CSS spinner, pending by default (no auto-dismiss, no progress bar).
- **`notify.loading(content, options?)`** — show a standalone loading toast.
- **`notify.promise(promise, { loading, success, error }, options?)`** — shows a loading toast, then swaps it **in place** to success or error when the promise settles (built on F4's upsert). `success`/`error` may be functions of the resolved value / error. Returns the original promise so callers can still `await`/chain it.

```ts
notify.promise(saveUser(), {
  loading: 'Saving…',
  success: (user) => `Saved ${user.name}`,
  error: (err) => `Save failed: ${err.message}`,
})
```

## Notable internal change
The Toast auto-dismiss timer now **(re)starts when `autoDismiss`/`timeOut` change**, not only on mount. This is what lets the in-place `loading → success/error` swap begin auto-dismissing — and it also fixes the F4 follow-up where `update()` couldn't restart a running timer.

## Verification
- **45 tests pass** (+5: loading toast, promise→success, promise→error with a function message, spinner render, timer-restart-on-prop-change).
- lint, typecheck, library build, demo build, `validate:package` (publint + attw) all green. gzip ~4.45 KB.
- **Manual browser smoke** (this is an Emotion change): drove the demo's new **Promise** button — verified the gray spinner loading toast renders and animates, then transitions in place to the error/success toast with a freshly-started progress bar. Type/success/warning toasts unregressed.

Purely additive API (`feat` → minor); no breaking changes.