### PR TITLE
feat(toast): animate toast enter/exit, respecting reduced motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ notify.closeAll()
 
 ## Customization
 
+> **Motion:** toasts animate in and out, and both animations are automatically
+> disabled for users who set `prefers-reduced-motion: reduce`.
+
 ### CSS custom properties
 
 All design tokens are exposed as CSS custom properties. Override them in plain CSS — no Emotion knowledge required.

--- a/src/components/ReactNoti/ReactNoti.test.tsx
+++ b/src/components/ReactNoti/ReactNoti.test.tsx
@@ -63,6 +63,32 @@ describe('<ReactNoti />', () => {
     expect(queryByTestId('react-noti-progress')).toBeNull()
   })
 
+  it('should keep a dismissed toast mounted until its exit window finishes', () => {
+    vi.useFakeTimers()
+    try {
+      const { queryByText } = render(<ReactNoti />)
+      let id = ''
+      act(() => {
+        id = notify.success('bye')
+      })
+      expect(queryByText('bye')).toBeTruthy()
+
+      // Removed from the store, but retained on screen while it animates out.
+      act(() => {
+        notify.dismiss(id)
+      })
+      expect(queryByText('bye')).toBeTruthy()
+
+      // After the exit window it is unmounted.
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+      expect(queryByText('bye')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('should render the same toast in every mounted container', () => {
     render(<ReactNoti />)
     render(<ReactNoti />)

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -4,6 +4,7 @@ import Toast, { type NotiClassNames } from '../Toast'
 import notify from '../../notify'
 import { defaultOptions, type Position } from '../../utils/constants'
 import { StyledReactNoti, StyledTray } from './ReactNoti.styled'
+import { useToastPresence } from './useToastPresence'
 
 export interface ReactNotiProps {
   position?: Position
@@ -40,6 +41,9 @@ export function ReactNoti({
     return pos === 'bottom' ? [...toasts].reverse() : toasts
   }, [toasts, position])
 
+  // Retain toasts through their exit animation after they leave the store.
+  const [renderedToasts, onExited] = useToastPresence(orderedToasts)
+
   useEffect(() => {
     notify.configure({
       autoDismiss,
@@ -56,9 +60,9 @@ export function ReactNoti({
       aria-live="polite"
       aria-atomic="false"
     >
-      {orderedToasts.length > 0 && (
+      {renderedToasts.length > 0 && (
         <StyledTray position={position}>
-          {orderedToasts.map((t) => (
+          {renderedToasts.map((t) => (
             <Toast
               key={t.id}
               id={t.id}
@@ -71,6 +75,8 @@ export function ReactNoti({
               pauseOnHover={t.pauseOnHover}
               showProgress={t.showProgress}
               onDismiss={notify.dismiss}
+              isLeaving={t.leaving}
+              onExited={onExited}
               classNames={classNames}
             />
           ))}

--- a/src/components/ReactNoti/useToastPresence.ts
+++ b/src/components/ReactNoti/useToastPresence.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { ToastItem } from '../../notify'
+
+export interface RenderedToast extends ToastItem {
+  leaving: boolean
+}
+
+/**
+ * Bridges the synchronous toast store with animated exits. Toasts removed from
+ * the store are retained here (marked `leaving`) so they can play their exit
+ * animation, then dropped once the animation reports completion via the
+ * returned `onExited` callback. The store itself stays purely synchronous.
+ */
+export function useToastPresence(
+  toasts: ToastItem[]
+): [RenderedToast[], (id: string) => void] {
+  const [rendered, setRendered] = useState<RenderedToast[]>(() =>
+    toasts.map((toast) => ({ ...toast, leaving: false }))
+  )
+
+  useEffect(() => {
+    setRendered((prev) => {
+      const storeIds = new Set(toasts.map((toast) => toast.id))
+      const merged: RenderedToast[] = toasts.map((toast) => ({
+        ...toast,
+        leaving: false,
+      }))
+
+      // Re-insert toasts that just left the store, marked `leaving`, at
+      // (approximately) their previous position so they don't jump while
+      // animating out.
+      prev.forEach((toast, index) => {
+        if (!storeIds.has(toast.id)) {
+          merged.splice(Math.min(index, merged.length), 0, {
+            ...toast,
+            leaving: true,
+          })
+        }
+      })
+
+      return merged
+    })
+  }, [toasts])
+
+  const onExited = useCallback((id: string) => {
+    setRendered((prev) => prev.filter((toast) => toast.id !== id))
+  }, [])
+
+  return [rendered, onExited]
+}

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -19,6 +19,28 @@ const rnSpin = keyframes`
   }
 `
 
+const rnEnter = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+`
+
+const rnLeave = keyframes`
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.96);
+  }
+`
+
 // Loading spinner (rendered in place of a type icon for the `loading` type)
 export const StyledSpinner = styled.span`
   display: inline-block;
@@ -32,8 +54,8 @@ export const StyledSpinner = styled.span`
 
 // Root
 export const StyledToast = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'type',
-})<{ type?: MsgType }>`
+  shouldForwardProp: (prop) => prop !== 'type' && prop !== 'isLeaving',
+})<{ type?: MsgType; isLeaving?: boolean }>`
   position: relative;
   display: flex;
   justify-content: center;
@@ -49,6 +71,12 @@ export const StyledToast = styled('div', {
 
   &:not(:last-child) {
     margin-bottom: 8px;
+  }
+
+  /* Enter/exit motion is opt-in for users who don't ask to reduce motion. */
+  @media (prefers-reduced-motion: no-preference) {
+    animation: ${({ isLeaving }) => (isLeaving ? rnLeave : rnEnter)}
+      ${({ isLeaving }) => (isLeaving ? '0.2s' : '0.25s')} ease both;
   }
 `
 // Icon

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -11,6 +11,8 @@ describe('<Toast />', () => {
     content: 'Hello',
     type: MSG_TYPE.SUCCESS,
     onDismiss: () => {},
+    isLeaving: false,
+    onExited: () => {},
     autoDismiss: defaultOptions.autoDismiss,
     timeOut: defaultOptions.timeOut,
     icons: defaultOptions.icons,
@@ -168,6 +170,33 @@ describe('<Toast />', () => {
     vi.runOnlyPendingTimers()
 
     expect(onDismissMockFn).toHaveBeenCalledWith(props.id)
+  })
+
+  it('should call onExited after the exit window when leaving', () => {
+    const onExitedMockFn = vi.fn()
+    const props = { ...defaultProps, isLeaving: true, onExited: onExitedMockFn }
+
+    render(<Toast {...props} />)
+
+    expect(onExitedMockFn).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(200)
+
+    expect(onExitedMockFn).toHaveBeenCalledWith(props.id)
+  })
+
+  it('should not auto-dismiss while leaving', () => {
+    const onDismissMockFn = vi.fn()
+    const props = {
+      ...defaultProps,
+      isLeaving: true,
+      onDismiss: onDismissMockFn,
+    }
+
+    render(<Toast {...props} />)
+    vi.runOnlyPendingTimers()
+
+    expect(onDismissMockFn).not.toHaveBeenCalled()
   })
 
   it('should apply classNames to toast slots', () => {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -7,8 +7,8 @@ import {
   type ReactElement,
 } from 'react'
 
-import { Timer } from '../../utils/helpers'
-import type { MsgType } from '../../utils/constants'
+import { Timer, prefersReducedMotion } from '../../utils/helpers'
+import { TOAST_EXIT_MS, type MsgType } from '../../utils/constants'
 
 import SuccessIcon from '../../assets/checked.svg?react'
 import InfoIcon from '../../assets/info.svg?react'
@@ -51,6 +51,8 @@ interface ToastProps {
   autoDismiss: boolean
   timeOut: number
   onDismiss: (id: string) => void
+  isLeaving: boolean
+  onExited: (id: string) => void
   icons: boolean
   pauseOnHover: boolean
   showProgress: boolean
@@ -65,6 +67,8 @@ function Toast({
   autoDismiss,
   timeOut,
   onDismiss,
+  isLeaving,
+  onExited,
   icons,
   pauseOnHover,
   showProgress,
@@ -79,8 +83,9 @@ function Toast({
 
   // (Re)start the auto-dismiss timer whenever the timing props change — this
   // is what lets an in-place update (e.g. loading -> success) begin dismissing.
+  // Skip once the toast is leaving so it isn't dismissed twice.
   useEffect(() => {
-    if (!autoDismiss || timeOut <= 0) {
+    if (isLeaving || !autoDismiss || timeOut <= 0) {
       setIsRunning(false)
       return undefined
     }
@@ -92,7 +97,20 @@ function Toast({
       timer.current?.clear()
       timer.current = null
     }
-  }, [autoDismiss, timeOut, id, onDismiss])
+  }, [autoDismiss, timeOut, id, onDismiss, isLeaving])
+
+  // Once removed from the store the toast is retained to play its exit
+  // animation; drop it after the animation window (immediately if the user
+  // prefers reduced motion).
+  useEffect(() => {
+    if (!isLeaving) return undefined
+
+    timer.current?.clear()
+    const delay = prefersReducedMotion() ? 0 : TOAST_EXIT_MS
+    const timeoutId = window.setTimeout(() => onExited(id), delay)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [isLeaving, id, onExited])
 
   const onMouseEnter = () => {
     if (!pauseOnHover || !timer.current) return
@@ -113,6 +131,7 @@ function Toast({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       type={type}
+      isLeaving={isLeaving}
     >
       {icons && (
         <StyledType role="img" aria-label={`alert ${type}`}>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -28,3 +28,7 @@ export const defaultOptions = {
   pauseOnHover: true,
   showProgress: true,
 } as const
+
+// Duration of the toast exit animation (ms). Kept in sync with the `rnLeave`
+// animation in Toast.styled.ts; the toast unmounts after this delay.
+export const TOAST_EXIT_MS = 200

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,6 +1,24 @@
-import { generateUID, Timer } from './helpers'
+import { generateUID, Timer, prefersReducedMotion } from './helpers'
 
 describe('helpers', () => {
+  describe('prefersReducedMotion()', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('returns false when the media query does not match', () => {
+      vi.stubGlobal('matchMedia', () => ({ matches: false }))
+
+      expect(prefersReducedMotion()).toBe(false)
+    })
+
+    it('returns true when the user prefers reduced motion', () => {
+      vi.stubGlobal('matchMedia', () => ({ matches: true }))
+
+      expect(prefersReducedMotion()).toBe(true)
+    })
+  })
+
   describe('generateUID()', () => {
     it('should generate unique ID', () => {
       const firstID = generateUID()

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -11,6 +11,14 @@ export function generateUID(): string {
   return `${time}-${count}-${rand}`
 }
 
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
 type TimerCallback = () => void
 
 export class Timer {


### PR DESCRIPTION
## Summary

Sixth feature (**F6**) of the roadmap. Toasts now animate **in** (fade + slide/scale) on mount and **out** on removal, and both animations respect `prefers-reduced-motion`.

## Design

The store stays **fully synchronous** — no changes to `notify.ts`. Exit animation is a pure view concern handled by a new `useToastPresence` hook in `ReactNoti`:

- A toast removed from the store (via `dismiss`, `closeAll`, timeout, or `single`) is **retained** in the rendered list, marked `leaving`, at its previous position.
- `Toast` plays the exit keyframes, then calls `onExited` after the exit window (`TOAST_EXIT_MS`, or **immediately** under reduced motion), and the hook drops it.

So `dismiss()` **and** `closeAll()` get exit animations for free, while the public API and store semantics are unchanged.

## Accessibility
Enter/exit keyframes are wrapped in `@media (prefers-reduced-motion: no-preference)`; when the user prefers reduced motion there is no animation and removal is instant (no reliance on `animationend`, which wouldn't fire).

## Files
- `src/components/ReactNoti/useToastPresence.ts` (new) — retain-until-exited bridge.
- `Toast.tsx` — `isLeaving`/`onExited` props, exit effect, auto-dismiss skipped while leaving.
- `Toast.styled.ts` — `rnEnter`/`rnLeave` keyframes, reduced-motion guard, `isLeaving` filtered from the DOM.
- `helpers.ts` — `prefersReducedMotion()`.

## Verification
- **50 tests pass** (+5: exit calls `onExited` after the window, no auto-dismiss while leaving, container keeps a dismissed toast mounted until the exit window ends, `prefersReducedMotion` true/false).
- lint, typecheck, library + demo build, `validate:package` all green. gzip ~4.89 KB.
- **Browser smoke** (headless Chrome): fired 3 toasts (all enter), dismissed one — it stayed mounted mid-exit (fade + slide-up captured) then unmounted after the window (count 3 → 3 → 2). No console errors introduced (the pre-existing `:nth-child` warning comes from the demo's `DemoPanel.styled.ts`, not the library).

Purely additive (`feat` → minor); no breaking changes.