### PR TITLE
feat(notify): add notify.custom for headless toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ notify.promise(saveUser(), {
   error: (err) => `Save failed: ${err.message}`,
 })
 
+// Fully custom, headless toast — you control the entire content. The render
+// function receives the toast id and a `dismiss` callback (no icon, title,
+// progress bar, or default close button are rendered).
+notify.custom(
+  ({ dismiss }) => (
+    <div className="my-toast">
+      <span>Custom content</span>
+      <button onClick={dismiss}>Close</button>
+    </div>
+  ),
+  { autoDismiss: false }
+)
+
 // Dismiss all toasts
 notify.closeAll()
 ```

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -75,6 +75,46 @@ function App() {
     )
   }
 
+  const handleCustomClick = () => {
+    notify.custom(
+      ({ dismiss }) => (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            width: '100%',
+            padding: 12,
+            color: '#fff',
+            background: '#1e1f20',
+            borderRadius: 8,
+          }}
+        >
+          <span role="img" aria-label="party">
+            🎉
+          </span>
+          <span>A fully custom, headless toast</span>
+          <button
+            type="button"
+            onClick={dismiss}
+            style={{
+              marginLeft: 'auto',
+              padding: '2px 10px',
+              color: '#fff',
+              background: 'transparent',
+              border: '1px solid rgba(255,255,255,0.5)',
+              borderRadius: 4,
+              cursor: 'pointer',
+            }}
+          >
+            Close
+          </button>
+        </div>
+      ),
+      { autoDismiss: false }
+    )
+  }
+
   return (
     <StyledApp className="App">
       <ReactNoti
@@ -97,6 +137,7 @@ function App() {
           handleTimeOutChange={handleTimeOutChange}
           handleOnClick={handleOnClick}
           handlePromiseClick={handlePromiseClick}
+          handleCustomClick={handleCustomClick}
           autoDismiss={autoDismiss}
           handleAutoDismissChange={handleAutoDismissChange}
           icons={icons}

--- a/examples/src/components/DemoPanel/DemoPanel.tsx
+++ b/examples/src/components/DemoPanel/DemoPanel.tsx
@@ -19,6 +19,7 @@ interface DemoPanelProps {
   handleTimeOutChange: (event: ChangeEvent<HTMLInputElement>) => void
   handleOnClick: (type: MsgType) => void
   handlePromiseClick: () => void
+  handleCustomClick: () => void
   autoDismiss: boolean
   handleAutoDismissChange: () => void
   icons: boolean
@@ -38,6 +39,7 @@ function DemoPanel({
   handleTimeOutChange,
   handleOnClick,
   handlePromiseClick,
+  handleCustomClick,
   autoDismiss,
   handleAutoDismissChange,
   icons,
@@ -77,6 +79,13 @@ function DemoPanel({
             onClick={handlePromiseClick}
           >
             promise
+          </StyledButton>
+          <StyledButton
+            type="button"
+            kind={MSG_TYPE.SUCCESS}
+            onClick={handleCustomClick}
+          >
+            custom
           </StyledButton>
         </StyledDemoButtons>
 

--- a/src/components/ReactNoti/ReactNoti.test.tsx
+++ b/src/components/ReactNoti/ReactNoti.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, act, fireEvent } from '@testing-library/react'
 
 import ReactNoti from './ReactNoti'
 import notify from '../../notify'
@@ -84,6 +84,36 @@ describe('<ReactNoti />', () => {
         vi.advanceTimersByTime(200)
       })
       expect(queryByText('bye')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('should render headless custom content and dismiss via the api', () => {
+    vi.useFakeTimers()
+    try {
+      const { getByText, queryByText } = render(<ReactNoti />)
+
+      act(() => {
+        notify.custom(
+          ({ dismiss }) => (
+            <button type="button" onClick={dismiss}>
+              close me
+            </button>
+          ),
+          { autoDismiss: false }
+        )
+      })
+      expect(getByText('close me')).toBeTruthy()
+
+      act(() => {
+        fireEvent.click(getByText('close me'))
+      })
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(queryByText('close me')).toBeNull()
     } finally {
       vi.useRealTimers()
     }

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -77,6 +77,7 @@ export function ReactNoti({
               onDismiss={notify.dismiss}
               isLeaving={t.leaving}
               onExited={onExited}
+              render={t.render}
               classNames={classNames}
             />
           ))}

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -54,20 +54,30 @@ export const StyledSpinner = styled.span`
 
 // Root
 export const StyledToast = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'type' && prop !== 'isLeaving',
-})<{ type?: MsgType; isLeaving?: boolean }>`
+  shouldForwardProp: (prop) =>
+    prop !== 'type' && prop !== 'isLeaving' && prop !== 'headless',
+})<{ type?: MsgType; isLeaving?: boolean; headless?: boolean }>`
   position: relative;
   display: flex;
   justify-content: center;
   width: 100%;
-  min-height: 48px;
-  max-height: 600px;
   color: var(--react-noti-color, ${colors.primary});
-  background-color: ${({ type }) =>
-    type ? `var(--react-noti-bg-${type}, ${colors[type]})` : '#fff'};
-  border-radius: var(--react-noti-radius, 4px);
-  overflow: hidden;
-  box-shadow: var(--react-noti-shadow, 0 3px 9px rgba(0, 0, 0, 0.175));
+
+  /* Headless (custom render) toasts drop all default chrome; the caller styles
+     the content themselves. They keep only the stacking gap and animation. */
+  ${({ headless, type }) =>
+    headless
+      ? 'background-color: transparent;'
+      : `
+    min-height: 48px;
+    max-height: 600px;
+    background-color: ${
+      type ? `var(--react-noti-bg-${type}, ${colors[type]})` : '#fff'
+    };
+    border-radius: var(--react-noti-radius, 4px);
+    overflow: hidden;
+    box-shadow: var(--react-noti-shadow, 0 3px 9px rgba(0, 0, 0, 0.175));
+  `}
 
   &:not(:last-child) {
     margin-bottom: 8px;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Timer, prefersReducedMotion } from '../../utils/helpers'
 import { TOAST_EXIT_MS, type MsgType } from '../../utils/constants'
+import type { ToastRender } from '../../notify'
 
 import SuccessIcon from '../../assets/checked.svg?react'
 import InfoIcon from '../../assets/info.svg?react'
@@ -56,6 +57,7 @@ interface ToastProps {
   icons: boolean
   pauseOnHover: boolean
   showProgress: boolean
+  render?: ToastRender
   classNames?: NotiClassNames
 }
 
@@ -72,6 +74,7 @@ function Toast({
   icons,
   pauseOnHover,
   showProgress,
+  render,
   classNames = {},
 }: ToastProps) {
   const timer = useRef<Timer | null>(null)
@@ -122,6 +125,22 @@ function Toast({
     if (!pauseOnHover || !timer.current) return
     timer.current.resume()
     setIsRunning(true)
+  }
+
+  // Headless toast: the caller's render controls everything inside the slot.
+  if (render) {
+    return (
+      <StyledToast
+        className={classNames.toast}
+        data-testid="react-noti-toast"
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        isLeaving={isLeaving}
+        headless
+      >
+        {render({ id, dismiss: handleDismiss })}
+      </StyledToast>
+    )
   }
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export type {
   NotifyConfig,
   RegisterOptions,
   PromiseMessages,
+  ToastRender,
+  ToastRenderApi,
 } from './notify'
 export type { NotiClassNames } from './components/Toast'
 export type { ReactNotiProps } from './components/ReactNoti'

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -110,6 +110,17 @@ describe('notify', () => {
     expect(handleStoreChangeMockFn).toHaveBeenCalledWith([])
   })
 
+  it('should create a headless toast carrying a render function', () => {
+    const render = vi.fn(() => null)
+
+    const id = notify.custom(render)
+
+    expect(id).toBe('aaa-bbb')
+    expect(handleStoreChangeMockFn).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'aaa-bbb', render, content: null }),
+    ])
+  })
+
   it('should create a non-dismissing loading toast', () => {
     notify.loading('Loading', { id: 'load-1' })
 

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -16,10 +16,21 @@ export interface ToastOptions {
   showProgress?: boolean
 }
 
+/** Handle passed to a custom render function. */
+export interface ToastRenderApi {
+  id: string
+  dismiss: () => void
+}
+
+/** Renders fully custom (headless) toast content. */
+export type ToastRender = (api: ToastRenderApi) => ReactNode
+
 export interface ToastItem extends Required<ToastOptions> {
   id: string
   type: MsgType
   content: ReactNode
+  /** When set, the toast is headless: this replaces all default chrome. */
+  render?: ToastRender
 }
 
 export interface NotifyConfig {
@@ -168,6 +179,33 @@ class Notify {
     )
 
     return promise
+  }
+
+  /**
+   * Show a headless toast whose content is fully controlled by `render`, which
+   * receives the toast id and a `dismiss` callback. No icon, title, progress
+   * bar, or default dismiss button is rendered.
+   */
+  custom = (render: ToastRender, options: ToastOptions = {}): string => {
+    const {
+      id = generateUID(),
+      autoDismiss = this.config.autoDismiss,
+      timeOut = this.config.timeOut,
+      pauseOnHover = this.config.pauseOnHover,
+    } = options
+    const toast: ToastItem = {
+      id,
+      type: MSG_TYPE.INFO, // unused: custom render bypasses type-based chrome
+      content: null,
+      title: '',
+      autoDismiss,
+      timeOut,
+      pauseOnHover,
+      showProgress: false,
+      render,
+    }
+    this.addToast(toast)
+    return id
   }
 
   /**


### PR DESCRIPTION
## Summary

Seventh feature (**F7**) of the roadmap. Lets consumers render fully bespoke toasts.

- **`notify.custom(render, options?)`** — `render` receives `{ id, dismiss }` and controls the entire toast content. No default icon, title, progress bar, or close button is rendered; the slot background is transparent so the caller styles everything.
- Custom toasts still get **stacking, enter/exit animation, auto-dismiss, and pause-on-hover** for free.
- Exports the render contract types **`ToastRender`** and **`ToastRenderApi`**.

```tsx
notify.custom(
  ({ dismiss }) => (
    <div className="my-toast">
      <span>Custom content</span>
      <button onClick={dismiss}>Close</button>
    </div>
  ),
  { autoDismiss: false }
)
```

## Implementation
- `notify.ts`: `ToastItem` gains an optional `render`; `custom()` builds a headless item (`content: null`, `showProgress: false`).
- `Toast.tsx`: when `render` is present, renders `render({ id, dismiss })` inside the animated slot and skips all default chrome.
- `Toast.styled.ts`: `StyledToast` gains a `headless` variant (transparent, no card styling) with `headless` filtered from the DOM.

## Verification
- **52 tests pass** (+2: `custom` stores the render fn & returns an id; headless content renders and its `dismiss` api removes the toast through the exit animation).
- lint, typecheck, library + demo build, `validate:package` all green. gzip ~5.14 KB.
- **Browser smoke**: fired the demo's new **Custom** button — a dark headless card (🎉 + custom Close button, no default chrome) rendered above a normal Info toast; clicking its own Close dismissed it (count 2 → 1). No console errors introduced.

Purely additive (`feat` → minor); no breaking changes.