### PR TITLE
feat(react-noti): add maxVisible to cap and queue toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ export default App
 | `icons`        | `boolean` | `true`        | ✘        | Show built-in icons on each toast. |
 | `pauseOnHover` | `boolean` | `true`        | ✘        | Pause the dismiss timer while the cursor is over a toast. |
 | `showProgress` | `boolean` | `true`        | ✘        | Show a progress bar counting down to dismiss. |
+| `maxVisible`   | `number`  | `0`           | ✘        | Max toasts shown at once; extras queue until a slot frees. `0` means unlimited. |
 | `className`    | `string`  | `undefined`   | ✘        | Extra CSS class added to the container element. |
 | `classNames`   | `NotiClassNames` | `undefined` | ✘   | Per-slot CSS classes for toast internals (see [Customization](#customization)). |
 

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -18,11 +18,14 @@ function App() {
   const [timeOut, setTimeOut] = useState<number>(5000)
   const [pauseOnHover, setPauseOnHover] = useState<boolean>(true)
   const [showProgress, setShowProgress] = useState<boolean>(true)
+  const [maxVisible, setMaxVisible] = useState<number>(0)
 
   const handlePositionChange = ({ target }: ChangeEvent<HTMLSelectElement>) =>
     setPosition(target.value as Position)
   const handleTimeOutChange = ({ target }: ChangeEvent<HTMLInputElement>) =>
     setTimeOut(Number(target.value) || 0)
+  const handleMaxVisibleChange = ({ target }: ChangeEvent<HTMLInputElement>) =>
+    setMaxVisible(Number(target.value) || 0)
   const handleAutoDismissChange = () => setAutoDismiss(!autoDismiss)
   const handleIconsChange = () => setIcons(!icons)
   const handleIsSingleChange = () => setIsSingle(!isSingle)
@@ -125,6 +128,7 @@ function App() {
         timeOut={timeOut}
         pauseOnHover={pauseOnHover}
         showProgress={showProgress}
+        maxVisible={maxVisible}
       />
 
       <Header />
@@ -135,6 +139,8 @@ function App() {
           handlePositionChange={handlePositionChange}
           timeOut={timeOut}
           handleTimeOutChange={handleTimeOutChange}
+          maxVisible={maxVisible}
+          handleMaxVisibleChange={handleMaxVisibleChange}
           handleOnClick={handleOnClick}
           handlePromiseClick={handlePromiseClick}
           handleCustomClick={handleCustomClick}

--- a/examples/src/components/DemoPanel/DemoPanel.tsx
+++ b/examples/src/components/DemoPanel/DemoPanel.tsx
@@ -17,6 +17,8 @@ interface DemoPanelProps {
   handlePositionChange: (event: ChangeEvent<HTMLSelectElement>) => void
   timeOut: number
   handleTimeOutChange: (event: ChangeEvent<HTMLInputElement>) => void
+  maxVisible: number
+  handleMaxVisibleChange: (event: ChangeEvent<HTMLInputElement>) => void
   handleOnClick: (type: MsgType) => void
   handlePromiseClick: () => void
   handleCustomClick: () => void
@@ -37,6 +39,8 @@ function DemoPanel({
   handlePositionChange,
   timeOut,
   handleTimeOutChange,
+  maxVisible,
+  handleMaxVisibleChange,
   handleOnClick,
   handlePromiseClick,
   handleCustomClick,
@@ -116,6 +120,18 @@ function DemoPanel({
                 placeholder="Enter timeOut"
                 onChange={handleTimeOutChange}
                 maxLength={4}
+              />
+            </label>
+            <label htmlFor="maxVisible">
+              <code>maxVisible</code>{' '}
+              <input
+                id="maxVisible"
+                type="text"
+                name="maxVisible"
+                value={maxVisible}
+                placeholder="0 = ∞"
+                onChange={handleMaxVisibleChange}
+                maxLength={2}
               />
             </label>
           </section>

--- a/src/components/ReactNoti/ReactNoti.test.tsx
+++ b/src/components/ReactNoti/ReactNoti.test.tsx
@@ -119,6 +119,39 @@ describe('<ReactNoti />', () => {
     }
   })
 
+  it('should show at most maxVisible toasts and queue the rest', () => {
+    vi.useFakeTimers()
+    try {
+      const { getByText, queryByText } = render(
+        <ReactNoti maxVisible={2} autoDismiss={false} />
+      )
+
+      act(() => {
+        notify.success('A', { id: 'a' })
+        notify.success('B', { id: 'b' })
+        notify.success('C', { id: 'c' })
+      })
+
+      // The two oldest are shown; the newest waits in the queue.
+      expect(getByText('A')).toBeTruthy()
+      expect(getByText('B')).toBeTruthy()
+      expect(queryByText('C')).toBeNull()
+
+      // Dismissing one frees a slot for the queued toast.
+      act(() => {
+        notify.dismiss('a')
+      })
+      expect(getByText('C')).toBeTruthy()
+
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+      expect(queryByText('A')).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('should render the same toast in every mounted container', () => {
     render(<ReactNoti />)
     render(<ReactNoti />)

--- a/src/components/ReactNoti/ReactNoti.tsx
+++ b/src/components/ReactNoti/ReactNoti.tsx
@@ -14,6 +14,8 @@ export interface ReactNotiProps {
   icons?: boolean
   pauseOnHover?: boolean
   showProgress?: boolean
+  /** Max toasts shown at once; extras queue until a slot frees. 0 = unlimited. */
+  maxVisible?: number
   className?: string
   classNames?: NotiClassNames
 }
@@ -26,6 +28,7 @@ export function ReactNoti({
   icons = defaultOptions.icons,
   pauseOnHover = defaultOptions.pauseOnHover,
   showProgress = defaultOptions.showProgress,
+  maxVisible = defaultOptions.maxVisible,
   className,
   classNames,
 }: ReactNotiProps) {
@@ -35,11 +38,21 @@ export function ReactNoti({
     notify.getServerSnapshot
   )
 
+  // Cap the number shown; extras wait in the store (unrendered, so their
+  // timers don't start) until an older toast leaves. Toasts are newest-first,
+  // so the oldest `maxVisible` stay visible and newer ones queue.
+  const visibleToasts = useMemo(() => {
+    if (!maxVisible || maxVisible <= 0 || toasts.length <= maxVisible) {
+      return toasts
+    }
+    return toasts.slice(-maxVisible)
+  }, [toasts, maxVisible])
+
   // Bottom positions render newest-last so it sits closest to the screen edge.
   const orderedToasts = useMemo(() => {
     const [pos] = position.split('-')
-    return pos === 'bottom' ? [...toasts].reverse() : toasts
-  }, [toasts, position])
+    return pos === 'bottom' ? [...visibleToasts].reverse() : visibleToasts
+  }, [visibleToasts, position])
 
   // Retain toasts through their exit animation after they leave the store.
   const [renderedToasts, onExited] = useToastPresence(orderedToasts)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -27,6 +27,7 @@ export const defaultOptions = {
   icons: true,
   pauseOnHover: true,
   showProgress: true,
+  maxVisible: 0, // 0 = unlimited
 } as const
 
 // Duration of the toast exit animation (ms). Kept in sync with the `rnLeave`


### PR DESCRIPTION
## Summary

Eighth feature (**F8**) of the roadmap — the first half of the split "stacking" work (per-toast `position` will follow as its own PR).

- New **`maxVisible`** prop on `<ReactNoti>`: shows at most that many toasts at once; extras **queue** and appear as older toasts leave. `0` (default) = unlimited.
- Queued toasts are simply not rendered, so **their auto-dismiss timers don't start** until they become visible — proper FIFO queueing.

## Design
Purely a **container/view concern** — no `notify.ts`/store changes. The store stays newest-first; `ReactNoti` slices to the oldest `maxVisible` (`slice(-maxVisible)`) **before** the `useToastPresence` hook, so when a slot frees the promoted toast animates in and the leaving one animates out.

## Verification
- **53 tests pass** (+1: with `maxVisible={2}`, firing 3 shows the two oldest and queues the third; dismissing one promotes the queued toast).
- lint, typecheck, library + demo build, `validate:package` all green. gzip ~5.19 KB.
- **Browser smoke**: added a `maxVisible` demo control, set it to `2`, fired 4 toasts → only 2 rendered; dismissed one → a queued toast filled the slot (count stayed 2). No console errors introduced.

Purely additive (`feat` → minor); no breaking changes.